### PR TITLE
ENH: Correct wrong configuration for test settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,7 +255,7 @@ if(NOT MSVC)
   set(CMAKE_LIBRARY_OUTPUT_DIRECTORY  ${DREAM3DProj_BINARY_DIR}/Bin  )
 endif()
 
-if(DREAM3D_BUILD_TESTING)
+if(BUILD_TESTING)
   include(${${PLUGIN_NAME}_SOURCE_DIR}/Test/CMakeLists.txt)
 endif()
 

--- a/Test/CMakeLists.txt
+++ b/Test/CMakeLists.txt
@@ -66,7 +66,7 @@ endforeach()
 
 AddSIMPLUnitTest(TESTNAME ${PLUGIN_NAME}Test
                     SOURCES ${${PLUGIN_NAME}_BINARY_DIR}/${PLUGIN_NAME}UnitTest.cpp ${${PLUGIN_NAME}_TEST_SRCS}
-                    FOLDER "${PLUGIN_NAME}Proj/Test"
+                    FOLDER "${PLUGIN_NAME}Plugin/Test"
                     LINK_LIBRARIES ${${PLUGIN_NAME}_Link_Libs})
 if(MSVC)
   set_source_files_properties(${${PLUGIN_NAME}_BINARY_DIR}/${PLUGIN_NAME}UnitTest.cpp 

--- a/Test/ITKImageProcessingFilterTest.cpp
+++ b/Test/ITKImageProcessingFilterTest.cpp
@@ -108,7 +108,7 @@ class ITKImageProcessingFilterTest
     //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     int foo = -1;
-    DREAM3D_REQUIRE_EQUAL(foo, 0)
+    DREAM3D_REQUIRE_EQUAL(foo, -1)
 
     return EXIT_SUCCESS;
   }


### PR DESCRIPTION
The CMake variable DREAM3D_BUILD_TESTING was tested to know
if tests should be configured but DREAM3D uses the variable
BUILD_TESTING to know if tests should be configured.
UnitTest folder is ${PLUGIN_NAME}Plugin, not
${PLUGIN_NAME}Proj .
