### PR TITLE
ENH: New ITK image type and itkImportImageContainer type

### DIFF
--- a/ITKImageProcessingFilters/Itk_BinaryThreshold.cpp
+++ b/ITKImageProcessingFilters/Itk_BinaryThreshold.cpp
@@ -18,6 +18,7 @@
 
 #include "ITKImageProcessing/ITKImageProcessingConstants.h"
 #include "ITKImageProcessing/ITKImageProcessingVersion.h"
+#include "ITKImageProcessing/ITKImageProcessingFilters/itkDream3DImage.h"
 #include "ITKImageProcessing/ITKImageProcessingFilters/itkInPlaceDream3DDataToImageFilter.h"
 #include "ITKImageProcessing/ITKImageProcessingFilters/itkInPlaceImageToDream3DDataFilter.h"
 
@@ -174,7 +175,7 @@ void Itk_BinaryThreshold::execute()
 
   const unsigned int Dimension = 3;
   typedef DefaultPixelType PixelType;
-  typedef itk::Image<PixelType, Dimension> ImageType;
+  typedef itk::Dream3DImage<PixelType, Dimension> ImageType;
   typedef itk::InPlaceDream3DDataToImageFilter<PixelType, Dimension> InPlaceDream3DDataToImageFilterType;
   const QString outputArrayName("Output Array");
 

--- a/ITKImageProcessingFilters/Itk_GaussianBlur.cpp
+++ b/ITKImageProcessingFilters/Itk_GaussianBlur.cpp
@@ -16,6 +16,7 @@
 
 #include "ITKImageProcessing/ITKImageProcessingConstants.h"
 #include "ITKImageProcessing/ITKImageProcessingVersion.h"
+#include "ITKImageProcessing/ITKImageProcessingFilters/itkDream3DImage.h"
 #include "ITKImageProcessing/ITKImageProcessingFilters/itkInPlaceDream3DDataToImageFilter.h"
 
 #include "sitkExplicitITK.h"
@@ -171,7 +172,7 @@ void Itk_GaussianBlur::execute()
 
   const unsigned int Dimension = 3;
   typedef DefaultPixelType PixelType;
-  typedef itk::Image<PixelType, Dimension> ImageType;
+  typedef itk::Dream3DImage<PixelType, Dimension> ImageType;
   typedef itk::InPlaceDream3DDataToImageFilter<PixelType, Dimension> FilterType;
   const QString outputArrayName("Output Array");
 

--- a/ITKImageProcessingFilters/SourceList.cmake
+++ b/ITKImageProcessingFilters/SourceList.cmake
@@ -54,6 +54,10 @@ ADD_SIMPL_SUPPORT_HEADER(${${PLUGIN_NAME}_SOURCE_DIR} ${_filterGroupName} itkInP
 ADD_SIMPL_SUPPORT_HEADER(${${PLUGIN_NAME}_SOURCE_DIR} ${_filterGroupName} itkInPlaceImageToDream3DDataFilter.hxx)
 ADD_SIMPL_SUPPORT_HEADER(${${PLUGIN_NAME}_SOURCE_DIR} ${_filterGroupName} itkInPlaceDream3DDataToImageFilter.h)
 ADD_SIMPL_SUPPORT_HEADER(${${PLUGIN_NAME}_SOURCE_DIR} ${_filterGroupName} itkInPlaceDream3DDataToImageFilter.hxx)
+ADD_SIMPL_SUPPORT_HEADER(${${PLUGIN_NAME}_SOURCE_DIR} ${_filterGroupName} itkDream3DImage.h)
+ADD_SIMPL_SUPPORT_HEADER(${${PLUGIN_NAME}_SOURCE_DIR} ${_filterGroupName} itkDream3DImage.hxx)
+ADD_SIMPL_SUPPORT_HEADER(${${PLUGIN_NAME}_SOURCE_DIR} ${_filterGroupName} itkImportDream3DImageContainer.h)
+ADD_SIMPL_SUPPORT_HEADER(${${PLUGIN_NAME}_SOURCE_DIR} ${_filterGroupName} itkImportDream3DImageContainer.hxx)
 
 #---------------------
 # This macro must come last after we are done adding all the filters and support files.

--- a/ITKImageProcessingFilters/itkDream3DImage.h
+++ b/ITKImageProcessingFilters/itkDream3DImage.h
@@ -1,0 +1,272 @@
+/*=========================================================================
+*
+*  Copyright Insight Software Consortium
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*         http://www.apache.org/licenses/LICENSE-2.0.txt
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+*=========================================================================*/
+#ifndef itkDream3DImage_h
+#define itkDream3DImage_h
+
+#include "itkImportDream3DImageContainer.h"
+#include "itkImage.h"
+#include "itkImageRegion.h"
+#include "itkDefaultPixelAccessor.h"
+#include "itkDefaultPixelAccessorFunctor.h"
+#include "itkPoint.h"
+#include "itkFixedArray.h"
+#include "itkWeakPointer.h"
+#include "itkNeighborhoodAccessorFunctor.h"
+
+namespace itk
+{
+  /** \class Dream3DImage
+  *  \brief Templated n-dimensional Dream3DImage class.
+  *
+  * Dream3DImages are templated over a pixel type (modeling the dependent
+  * variables), and a dimension (number of independent variables).  The
+  * container for the pixel data is the templated ImportImageContainer.
+  *
+  * Within the pixel container, Dream3DImages are modelled as arrays, defined by a
+  * start index and a size.
+  *
+  * The superclass of Dream3DImage, Image, defines the geometry of the
+  * image in terms of where the image sits in physical space, how the
+  * image is oriented in physical space, the size of a pixel, and the
+  * extent of the image itself.  ImageBase provides the methods to
+  * convert between the index and physical space coordinate frames.
+  *
+  * Pixels can be accessed direcly using the SetPixel() and GetPixel()
+  * methods or can be accessed via iterators that define the region of
+  * the image they traverse.
+  *
+  * The pixel type may be one of the native types; a Insight-defined
+  * class type such as Vector; or a user-defined type. Note that
+  * depending on the type of pixel that you use, the process objects
+  * (i.e., those filters processing data objects) may not operate on
+  * the image and/or pixel type. This becomes apparent at compile-time
+  * because operator overloading (for the pixel type) is not supported.
+  *
+  * The data in an image is arranged in a 1D array as [][][][slice][row][col]
+  * with the column index varying most rapidly.  The Index type reverses
+  * the order so that with Index[0] = col, Index[1] = row, Index[2] = slice,
+  * ...
+  *
+  * Memory is manage with malloc and free instead of respectively new and
+  * delete. This is useful if one needs to import the data container from
+  * or export the data to a section of code that manages memory with malloc
+  * and free. The behavior of mixing malloc/free and new/delete is undefined
+  * and should be avoided. 
+  *
+  * \sa Image
+  * \sa ImageBase
+  * \sa ImageContainerInterface
+  *
+  * \ingroup ImageObjects
+  * \ingroup ITKCommon
+  *
+  * \wiki
+  * \wikiexample{SimpleOperations/SetPixels,Set specified pixels to specified values}
+  * \endwiki
+  */
+  template< typename TPixel, unsigned int VImageDimension = 2 >
+  class Dream3DImage :public Image< TPixel, VImageDimension >
+  {
+  public:
+    /** Standard class typedefs */
+    typedef Dream3DImage      Self;
+    typedef Image< TPixel,VImageDimension >     Superclass;
+    typedef SmartPointer< Self >         Pointer;
+    typedef SmartPointer< const Self >   ConstPointer;
+    typedef WeakPointer< const Self >    ConstWeakPointer;
+
+    /** Method for creation through the object factory. */
+    itkNewMacro( Self );
+
+    /** Run-time type information (and related methods). */
+    itkTypeMacro( Dream3DImage, Image );
+
+    /** Pixel typedef support. Used to declare pixel type in filters
+    * or other operations. */
+    typedef TPixel PixelType;
+
+    /** Typedef alias for PixelType */
+    typedef TPixel ValueType;
+
+    /** Internal Pixel representation. Used to maintain a uniform API
+    * with Image Adaptors and allow to keep a particular internal
+    * representation of data while showing a different external
+    * representation. */
+    typedef TPixel InternalPixelType;
+
+    typedef PixelType IOPixelType;
+
+    /** Accessor type that convert data between internal and external
+    *  representations.  */
+    typedef DefaultPixelAccessor< PixelType >   AccessorType;
+    typedef DefaultPixelAccessorFunctor< Self > AccessorFunctorType;
+
+    /** Typedef for the functor used to access a neighborhood of pixel
+    * pointers. */
+    typedef NeighborhoodAccessorFunctor< Self > NeighborhoodAccessorFunctorType;
+
+    /** Type of image dimension */
+    typedef typename Superclass::ImageDimensionType ImageDimensionType;
+
+    /** Index typedef support. An index is used to access pixel values. */
+    typedef typename Superclass::IndexType      IndexType;
+    typedef typename Superclass::IndexValueType IndexValueType;
+
+    /** Offset typedef support. An offset is used to access pixel values. */
+    typedef typename Superclass::OffsetType OffsetType;
+
+    /** Size typedef support. A size is used to define region bounds. */
+    typedef typename Superclass::SizeType      SizeType;
+    typedef typename Superclass::SizeValueType SizeValueType;
+
+    /** Direction typedef support. A matrix of direction cosines. */
+    typedef typename Superclass::DirectionType DirectionType;
+
+    /** Region typedef support. A region is used to specify a subset of an image.
+    */
+    typedef typename Superclass::RegionType RegionType;
+
+    /** Spacing typedef support.  Spacing holds the size of a pixel.  The
+    * spacing is the geometric distance between image samples. */
+    typedef typename Superclass::SpacingType      SpacingType;
+    typedef typename Superclass::SpacingValueType SpacingValueType;
+
+    /** Origin typedef support.  The origin is the geometric coordinates
+    * of the index (0,0). */
+    typedef typename Superclass::PointType PointType;
+
+    /** A pointer to the pixel container. */
+    typedef ImportDream3DImageContainer< itk::SizeValueType, TPixel >          PixelContainerType;
+    typedef typename PixelContainerType::Pointer                               PixelContainerPointer;
+    typedef typename PixelContainerType::ConstPointer                          PixelContainerConstPointer;
+
+    /** Offset typedef (relative position between indices) */
+    typedef typename Superclass::OffsetValueType OffsetValueType;
+
+    /** Allocate the image memory. The size of the image must
+    * already be set, e.g. by calling SetRegions(). */
+    virtual void Allocate( bool initializePixels = false ) ITK_OVERRIDE;
+
+    /** Restore the data object to its initial state. This means releasing
+    * memory. */
+    virtual void Initialize() ITK_OVERRIDE;
+
+    /** Fill the image buffer with a value.  Be sure to call Allocate()
+    * first. */
+    void FillBuffer( const TPixel & value );
+
+    /** \brief Set a pixel value.
+    *
+    * Allocate() needs to have been called first -- for efficiency,
+    * this function does not check that the image has actually been
+    * allocated yet. */
+    void SetPixel( const IndexType & index, const TPixel & value )
+    {
+      OffsetValueType offset = this->FastComputeOffset( index );
+      (*m_TemplatedBuffer)[offset] = value;
+    }
+
+    /** \brief Get a pixel (read only version).
+    *
+    * For efficiency, this function does not check that the
+    * image has actually been allocated yet. */
+    const TPixel & GetPixel( const IndexType & index ) const
+    {
+      OffsetValueType offset = this->FastComputeOffset( index );
+      return ((*m_TemplatedBuffer)[offset]);
+    }
+
+    /** \brief Get a reference to a pixel (e.g. for editing).
+    *
+    * For efficiency, this function does not check that the
+    * image has actually been allocated yet. */
+    TPixel & GetPixel( const IndexType & index )
+    {
+      OffsetValueType offset = this->FastComputeOffset( index );
+      return ((*m_TemplatedBuffer)[offset]);
+    }
+
+    /** Return a pointer to the beginning of the buffer.  This is used by
+    * the image iterator class. */
+    virtual TPixel * GetBufferPointer()
+    {
+      return m_TemplatedBuffer ? m_TemplatedBuffer->GetBufferPointer() : ITK_NULLPTR;
+    }
+    virtual const TPixel * GetBufferPointer() const
+    {
+      return m_TemplatedBuffer ? m_TemplatedBuffer->GetBufferPointer() : ITK_NULLPTR;
+    }
+
+    /** Return a pointer to the container. */
+    PixelContainerType * GetPixelContainer()
+    {
+      return m_TemplatedBuffer.GetPointer();
+    }
+
+    const PixelContainerType * GetPixelContainer() const
+    {
+      return m_TemplatedBuffer.GetPointer();
+    }
+
+    /** Set the container to use. Note that this does not cause the
+    * DataObject to be modified. */
+    void SetPixelContainer( PixelContainerType *container );
+
+    /** Return the Pixel Accessor object */
+    AccessorType GetPixelAccessor( void )
+    {
+      return AccessorType();
+    }
+
+    /** Return the Pixel Accesor object */
+    const AccessorType GetPixelAccessor( void ) const
+    {
+      return AccessorType();
+    }
+
+    /** Return the NeighborhoodAccessor functor */
+    NeighborhoodAccessorFunctorType GetNeighborhoodAccessor()
+    {
+      return NeighborhoodAccessorFunctorType();
+    }
+
+    /** Return the NeighborhoodAccessor functor */
+    const NeighborhoodAccessorFunctorType GetNeighborhoodAccessor() const
+    {
+      return NeighborhoodAccessorFunctorType();
+    }
+  protected:
+    Dream3DImage();
+    void PrintSelf( std::ostream & os, Indent indent ) const ITK_OVERRIDE;
+
+    virtual ~Dream3DImage() {}
+
+  private:
+    Dream3DImage( const Self & ) ITK_DELETE_FUNCTION;
+    void operator=(const Self &)ITK_DELETE_FUNCTION;
+
+    /** Memory for the current buffer. */
+    PixelContainerPointer m_TemplatedBuffer;
+  };
+} // end namespace itk
+
+#ifndef ITK_MANUAL_INSTANTIATION
+#include "itkDream3DImage.hxx"
+#endif
+
+#endif

--- a/ITKImageProcessingFilters/itkDream3DImage.hxx
+++ b/ITKImageProcessingFilters/itkDream3DImage.hxx
@@ -1,0 +1,122 @@
+/*=========================================================================
+*
+*  Copyright Insight Software Consortium
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*         http://www.apache.org/licenses/LICENSE-2.0.txt
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+*=========================================================================*/
+/*=========================================================================
+*
+*  Portions of this file are subject to the VTK Toolkit Version 3 copyright.
+*
+*  Copyright (c) Ken Martin, Will Schroeder, Bill Lorensen
+*
+*  For complete copyright, license and disclaimer of warranty information
+*  please refer to the NOTICE file at the top of the ITK source tree.
+*
+*=========================================================================*/
+#ifndef itkDream3DImage_hxx
+#define itkDream3DImage_hxx
+
+#include "itkDream3DImage.h"
+#include "itkProcessObject.h"
+#include <algorithm>
+
+namespace itk
+{
+
+  template< typename TPixel, unsigned int VImageDimension >
+  Dream3DImage< TPixel, VImageDimension >
+    ::Dream3DImage()
+  {
+    m_TemplatedBuffer = PixelContainerType::New();
+  }
+
+
+  template< typename TPixel, unsigned int VImageDimension >
+  void
+    Dream3DImage< TPixel, VImageDimension >
+    ::Allocate( bool initializePixels )
+  {
+    SizeValueType num;
+
+    this->ComputeOffsetTable();
+    num = static_cast<SizeValueType>(this->GetOffsetTable()[VImageDimension]);
+
+    m_TemplatedBuffer->Reserve( num, initializePixels );
+  }
+
+
+  template< typename TPixel, unsigned int VImageDimension >
+  void
+    Dream3DImage< TPixel, VImageDimension >
+    ::Initialize()
+  {
+    //
+    // We don't modify ourselves because the "ReleaseData" methods depend upon
+    // no modification when initialized.
+    //
+
+    // Call the superclass which should initialize the BufferedRegion ivar.
+    // Skip itk::Image::Initialize(), to overwrite it.
+    Superclass::Superclass::Initialize();
+
+    // Replace the handle to the buffer. This is the safest thing to do,
+    // since the same container can be shared by multiple images (e.g.
+    // Grafted outputs and in place filters).
+    m_TemplatedBuffer = PixelContainerType::New();
+  }
+
+
+  template< typename TPixel, unsigned int VImageDimension >
+  void
+    Dream3DImage< TPixel, VImageDimension >
+    ::FillBuffer( const TPixel & value )
+  {
+    const SizeValueType numberOfPixels =
+      this->GetBufferedRegion().GetNumberOfPixels();
+
+    std::fill_n( &(*m_TemplatedBuffer)[0], numberOfPixels, value );
+  }
+
+
+  template< typename TPixel, unsigned int VImageDimension >
+  void
+    Dream3DImage< TPixel, VImageDimension >
+    ::SetPixelContainer( PixelContainerType *container )
+  {
+    if( m_TemplatedBuffer != container )
+    {
+      m_TemplatedBuffer = container;
+      this->Modified();
+    }
+  }
+
+
+
+  template< typename TPixel, unsigned int VImageDimension >
+  void
+    Dream3DImage< TPixel, VImageDimension >
+    ::PrintSelf( std::ostream & os, Indent indent ) const
+  {
+    Superclass::PrintSelf( os, indent );
+
+    os << indent << "PixelContainer: " << std::endl;
+    m_TemplatedBuffer->Print( os, indent.GetNextIndent() );
+
+    // m_Origin and m_Spacing are printed in the Superclass
+  }
+
+} // end namespace itk
+
+#endif

--- a/ITKImageProcessingFilters/itkImportDream3DImageContainer.h
+++ b/ITKImageProcessingFilters/itkImportDream3DImageContainer.h
@@ -1,0 +1,96 @@
+/*=========================================================================
+*
+*  Copyright Insight Software Consortium
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*         http://www.apache.org/licenses/LICENSE-2.0.txt
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+*=========================================================================*/
+#ifndef itkImportDream3DImageContainer_h
+#define itkImportDream3DImageContainer_h
+
+#include "itkImportImageContainer.h"
+
+namespace itk
+{
+  /** \class ImportDream3DImageContainer
+  *  \brief Defines an itk::Image front-end to a standard C-array.
+  *
+  * Defines an itk::Image front-end to a standard C-array. This container
+  * conforms to the ImageContainerInterface. This is a full-fleged Object,
+  * so there is modification time, debug, and reference count information.
+  * Memory is manage with malloc and free instead of respectively new and
+  * delete. This is useful if one needs to import the data container from
+  * or export the data to a section of code that manages memory with malloc
+  * and free. The behavior of mixing malloc/free and new/delete is undefined
+  * and should be avoided. 
+  *
+  * \tparam TElementIdentifier An INTEGRAL type for use in indexing the
+  * imported buffer.
+  *
+  * \tparam TElement The element type stored in the container.
+  *
+  * \ingroup ImageObjects
+  * \ingroup IOFilters
+  * \ingroup ITKCommon
+  */
+
+  template< typename TElementIdentifier, typename TElement >
+  class ImportDream3DImageContainer :public ImportImageContainer<TElementIdentifier,TElement >
+  {
+  public:
+    /** Standard class typedefs. */
+    typedef ImportDream3DImageContainer                          Self;
+    typedef ImportImageContainer<TElementIdentifier, TElement >  Superclass;
+    typedef SmartPointer< Self >                                 Pointer;
+    typedef SmartPointer< const Self >                           ConstPointer;
+
+    /** Save the template parameters. */
+    typedef typename Superclass::ElementIdentifier ElementIdentifier;
+    typedef typename Superclass::Element           Element;
+
+    /** Method for creation through the object factory. */
+    itkNewMacro( Self );
+
+    /** Standard part of every itk Object. */
+    itkTypeMacro( ImportDream3DImageContainer, ImportImageContainer );
+
+  protected:
+    ImportDream3DImageContainer();
+    virtual ~ImportDream3DImageContainer();
+
+    /** PrintSelf routine. Normally this is a protected internal method. It is
+    * made public here so that Image can call this method.  Users should not
+    * call this method but should call Print() instead. */
+    virtual void PrintSelf( std::ostream & os, Indent indent ) const ITK_OVERRIDE;
+
+    /**
+    * Allocates elements of the array.  If UseDefaultConstructor is true, then
+    * the default constructor is used to initialize each element.  POD date types
+    * initialize to zero.
+    */
+    virtual Element * AllocateElements( ElementIdentifier size, bool UseDefaultConstructor = false ) const;
+
+    virtual void DeallocateManagedMemory();
+
+  private:
+    ImportDream3DImageContainer( const Self & ) ITK_DELETE_FUNCTION;
+    void operator=(const Self &)ITK_DELETE_FUNCTION;
+
+  };
+} // end namespace itk
+
+#ifndef ITK_MANUAL_INSTANTIATION
+#include "itkImportDream3DImageContainer.hxx"
+#endif
+
+#endif

--- a/ITKImageProcessingFilters/itkImportDream3DImageContainer.hxx
+++ b/ITKImageProcessingFilters/itkImportDream3DImageContainer.hxx
@@ -1,0 +1,106 @@
+/*=========================================================================
+*
+*  Copyright Insight Software Consortium
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*         http://www.apache.org/licenses/LICENSE-2.0.txt
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+*=========================================================================*/
+/*=========================================================================
+*
+*  Portions of this file are subject to the VTK Toolkit Version 3 copyright.
+*
+*  Copyright (c) Ken Martin, Will Schroeder, Bill Lorensen
+*
+*  For complete copyright, license and disclaimer of warranty information
+*  please refer to the NOTICE file at the top of the ITK source tree.
+*
+*=========================================================================*/
+#ifndef itkImportDream3DImageContainer_hxx
+#define itkImportDream3DImageContainer_hxx
+
+#include "itkImportDream3DImageContainer.h"
+
+namespace itk
+{
+  template< typename TElementIdentifier, typename TElement >
+  ImportDream3DImageContainer< TElementIdentifier, TElement >
+    ::ImportDream3DImageContainer()
+  {
+  }
+
+  template< typename TElementIdentifier, typename TElement >
+  ImportDream3DImageContainer< TElementIdentifier, TElement >
+    ::~ImportDream3DImageContainer()
+  {
+    DeallocateManagedMemory();
+  }
+
+  template< typename TElementIdentifier, typename TElement >
+  typename ImportDream3DImageContainer< TElementIdentifier, TElement >::Element *
+  ImportDream3DImageContainer< TElementIdentifier, TElement >
+    ::AllocateElements( ElementIdentifier size, bool UseDefaultConstructor ) const
+  {
+  // Encapsulate all image memory allocation here to throw an
+  // exception when memory allocation fails even when the compiler
+  // does not do this by default.
+  Element *data;
+
+  try
+    {
+    data = (Element*)(malloc( sizeof( TElement ) * size ));
+    if ( UseDefaultConstructor )
+      {
+        new (data)Element();//POD types initialized to 0, others use default constructor.
+      }
+    }
+  catch ( ... )
+    {
+    data = ITK_NULLPTR;
+    }
+  if ( !data )
+    {
+    // We cannot construct an error string here because we may be out
+    // of memory.  Do not use the exception macro.
+    throw MemoryAllocationError(__FILE__, __LINE__,
+                                "Failed to allocate memory for image.",
+                                ITK_LOCATION);
+    }
+  return data;
+  }
+
+  template< typename TElementIdentifier, typename TElement >
+  void
+  ImportDream3DImageContainer< TElementIdentifier, TElement >
+    ::DeallocateManagedMemory()
+  {
+    // Encapsulate all image memory deallocation here
+    if( this->GetContainerManageMemory() )
+    {
+      Element *data = this->GetBufferPointer();
+      data->~Element();
+      free( data );
+      this->SetImportPointer( ITK_NULLPTR );
+    }
+    Superclass::DeallocateManagedMemory();
+  }
+
+  template< typename TElementIdentifier, typename TElement >
+  void
+  ImportDream3DImageContainer< TElementIdentifier, TElement >
+    ::PrintSelf( std::ostream & os, Indent indent ) const
+  {
+    Superclass::PrintSelf( os, indent );
+  }
+} // end namespace itk
+
+#endif

--- a/ITKImageProcessingFilters/itkInPlaceDream3DDataToImageFilter.h
+++ b/ITKImageProcessingFilters/itkInPlaceDream3DDataToImageFilter.h
@@ -1,25 +1,25 @@
 #ifndef _itkInPlaceDream3DDataToImageFilter_h
 #define _itkInPlaceDream3DDataToImageFilter_h
 
+#include "itkDream3DImage.h"
 #include <itkImportImageFilter.h>
 
 namespace itk
 {
   template< typename PixelType, unsigned int VDimension >
-  class InPlaceDream3DDataToImageFilter : public ImageSource< itk::Image<PixelType, VDimension> >
+  class InPlaceDream3DDataToImageFilter : public ImageSource< itk::Dream3DImage<PixelType, VDimension > >
   {
   public:
     /** Standard class typedefs. */
     typedef InPlaceDream3DDataToImageFilter                                 Self;
     typedef SmartPointer<Self>                                              Pointer;
-    typedef typename itk::Image<PixelType, VDimension>                      ImageType;
+    typedef typename itk::Dream3DImage<PixelType, VDimension >              ImageType;
+    typedef typename ImageType::PixelContainerType                          ImportImageContainerType;
+
     typedef typename ImageType::Pointer                                     ImagePointer;
     typedef typename ::DataArray<PixelType>                                 DataArrayPixelType;
-    typedef typename itk::ImageSource< itk::Image<PixelType, VDimension> >  Superclass;
-    typedef itk::SizeValueType                                              SizeValueType;
-    typedef ImportImageContainer< SizeValueType, PixelType >                ImportImageContainerType;
-    typedef Image< PixelType, VDimension >                                  OutputImageType;
-    typedef typename OutputImageType::Pointer                               OutputImagePointer;
+    typedef typename itk::ImageSource< ImageType >                          Superclass;
+    typedef typename itk::SizeValueType                                     SizeValueType;
 
     /** Method for creation through the object factory. */
     itkNewMacro(Self);

--- a/ITKImageProcessingFilters/itkInPlaceDream3DDataToImageFilter.hxx
+++ b/ITKImageProcessingFilters/itkInPlaceDream3DDataToImageFilter.hxx
@@ -110,7 +110,7 @@ InPlaceDream3DDataToImageFilter< PixelType, VDimension >
     size[i] = tDims[i];
   }
   // get pointer to the output
-  OutputImagePointer outputPtr = this->GetOutput();
+  ImagePointer outputPtr = this->GetOutput();
 
   // we need to compute the output spacing, the output origin, the
   // output image size, and the output image start index
@@ -148,7 +148,7 @@ InPlaceDream3DDataToImageFilter< PixelType, VDimension >
       size, pixelContainerWillOwnTheBuffer );
   }
   // get pointer to the output
-  OutputImagePointer outputPtr = this->GetOutput();
+  ImagePointer outputPtr = this->GetOutput();
   outputPtr->SetBufferedRegion( outputPtr->GetLargestPossibleRegion() );
   outputPtr->SetPixelContainer( m_ImportImageContainer );
  }

--- a/ITKImageProcessingFilters/itkInPlaceImageToDream3DDataFilter.h
+++ b/ITKImageProcessingFilters/itkInPlaceImageToDream3DDataFilter.h
@@ -1,7 +1,7 @@
 #ifndef _ITKInPlaceImageToDream3DDataFilter_h
 #define _ITKInPlaceImageToDream3DDataFilter_h
 
-#include "itkImage.h"
+#include "itkDream3DImage.h"
 #include "itkProcessObject.h"
 #include "itkSimpleDataObjectDecorator.h"
 #include "SIMPLib/DataContainers/DataContainerArray.h"
@@ -17,7 +17,7 @@ namespace itk
     typedef InPlaceImageToDream3DDataFilter                                  Self;
     typedef ProcessObject                                                    Superclass;
     typedef SmartPointer<Self>                                               Pointer;
-    typedef typename itk::Image<PixelType, VDimension>                       ImageType;
+    typedef typename itk::Dream3DImage<PixelType, VDimension>               ImageType;
     typedef typename ImageType::Pointer                                      ImagePointer;
     typedef typename ::DataArray<PixelType>                                  DataArrayPixelType;
     typedef typename itk::SimpleDataObjectDecorator<DataContainer::Pointer>  DecoratorType;

--- a/Test/ITKImageProcessingFilterTest.cpp
+++ b/Test/ITKImageProcessingFilterTest.cpp
@@ -44,8 +44,7 @@
 #include "SIMPLib/Utilities/UnitTestSupport.hpp"
 #include "SIMPLib/Utilities/QMetaObjectUtilities.h"
 
-#include <itkImage.h>
-
+#include "ITKImageProcessing/ITKImageProcessingFilters/itkDream3DImage.h"
 #include "ITKImageProcessing/ITKImageProcessingFilters/itkInPlaceImageToDream3DDataFilter.h"
 #include "ITKImageProcessing/ITKImageProcessingFilters/itkInPlaceDream3DDataToImageFilter.h"
 
@@ -89,15 +88,14 @@ class ITKImageProcessingFilterTest
     return 0;
   }
 
-  template<class PixelType, unsigned int dimension>
-  typename itk::Image<PixelType, dimension>::Pointer
-  CreateITKImageForTests(typename itk::Image<PixelType, dimension>::PointType &origin,
-                         typename itk::Image<PixelType, dimension>::SizeType &size,
-                         typename itk::Image<PixelType, dimension>::SpacingType &spacing,
-                         PixelType value
+  template<class ImageType>
+  typename ImageType::Pointer
+  CreateITKImageForTests(typename ImageType::PointType &origin,
+                         typename ImageType::SizeType &size,
+                         typename ImageType::SpacingType &spacing,
+                         typename ImageType::PixelType value
                         )
   {
-    typedef itk::Image<PixelType, dimension> ImageType;
     typename ImageType::Pointer image = ImageType::New();
     typename ImageType::DirectionType direction;
     direction.SetIdentity();
@@ -124,7 +122,7 @@ class ITKImageProcessingFilterTest
     //////////////////////////////////////////////////
     DataContainer::Pointer dc = DataContainer::New("TestContainer");
     typedef float PixelType;
-    typedef itk::Image<PixelType, dimension> ImageType;
+    typedef itk::Dream3DImage<PixelType, dimension> ImageType;
     ImageType::PointType origin;
     ImageType::SizeType size;
     ImageType::SpacingType spacing;
@@ -134,7 +132,7 @@ class ITKImageProcessingFilterTest
       size[i] = 90 + i * 3;
       spacing[i] = .45 + float(i)*.2;
     }
-    ImageType::Pointer image = CreateITKImageForTests<PixelType,dimension>(origin, size, spacing, 12);
+    ImageType::Pointer image = CreateITKImageForTests<ImageType>(origin, size, spacing, 12);
     ImageType::IndexType index;
     index.Fill(0);
     //float val=image->GetPixel(index);
@@ -229,7 +227,7 @@ class ITKImageProcessingFilterTest
     typedef int PixelType;
     // beginning of the local scope in which the image is created
     {
-      typedef itk::Image<PixelType, dimension> ImageType;
+      typedef itk::Dream3DImage<PixelType, dimension> ImageType;
       ImageType::PointType origin;
       ImageType::SizeType size;
       ImageType::SpacingType spacing;
@@ -239,7 +237,7 @@ class ITKImageProcessingFilterTest
         size[i] = 90 + i * 3;
         spacing[i] = .45 + float(i)*.2;
       }
-      ImageType::Pointer image = CreateITKImageForTests<PixelType, dimension>(origin, size, spacing, initialValue);
+      ImageType::Pointer image = CreateITKImageForTests<ImageType>( origin, size, spacing, initialValue );
       // Create converter
       typedef itk::InPlaceImageToDream3DDataFilter<PixelType, dimension> InPlaceImageToDream3DDataFilterType;
       InPlaceImageToDream3DDataFilterType::Pointer filter = InPlaceImageToDream3DDataFilterType::New();
@@ -304,7 +302,7 @@ class ITKImageProcessingFilterTest
     ma->addAttributeArray(dataArrayName, data);
 
     // Create filter
-    typedef itk::Image<PixelType, Dimension> ImageType;
+    typedef itk::Dream3DImage<PixelType, Dimension> ImageType;
     typedef itk::InPlaceDream3DDataToImageFilter<PixelType, Dimension> FilterType;
     FilterType::Pointer filter = FilterType::New();
     filter->SetInput(dc);
@@ -356,7 +354,7 @@ class ITKImageProcessingFilterTest
   {
     const unsigned int Dimension = 3;
     typedef int PixelType;
-    typedef itk::Image<PixelType, Dimension> ImageType;
+    typedef itk::Dream3DImage<PixelType, Dimension> ImageType;
     ImageType::Pointer image;
     PixelType initial_value = 11 ;
     size_t dataSize;
@@ -416,6 +414,7 @@ class ITKImageProcessingFilterTest
 
     DREAM3D_REGISTER_TEST( TestFilterAvailability() );
 
+    // Test filters
     DREAM3D_REGISTER_TEST(TestImageToDream3DData(false))
     DREAM3D_REGISTER_TEST(TestImageToDream3DDataOutOfScope(false))
     DREAM3D_REGISTER_TEST(TestDream3DDataToImage(false))


### PR DESCRIPTION
itkImages allocates memory using 'new' and frees the memory using
'delete'. One who uses ITK, might have used 'malloc' and 'free' instead
to allocate memory. If the allocated memory is then managed by ITK, this
might result in an undefined behavior.
To avoid having to copy the memory to avoid the undefined behavior,
itkImportImageMallocContainer allocates memory with malloc and frees
memory with free. itkImageContainerTemplated allows to specify what type
of itkImportImageContainer is used. These two new classes allow one
to import images in ITK, which memory has been allocated with 'malloc'
and 'free' without running into problems.
