### PR TITLE
BUG: itkNrrdImageIOFactory.h file name given as itkNRRDImageIOFactory.h

### DIFF
--- a/ITKImageProcessingFilters/ITKImageReader.cpp
+++ b/ITKImageProcessingFilters/ITKImageReader.cpp
@@ -47,7 +47,7 @@
 #include <itkImageFileReader.h>
 #include <itkImageIOFactory.h>
 #include <itkMetaImageIOFactory.h>
-#include <itkNRRDImageIOFactory.h>
+#include <itkNrrdImageIOFactory.h>
 #include <itkPNGImageIOFactory.h>
 
 // ITK-SCIFIO


### PR DESCRIPTION
The case of the file name was wrong. It does not matter on Windows but it does
on Linux.
