### PR TITLE
BUG: itkNrrdImageIOFactory.h file name given as itkNRRDImageIOFactory.h

### DIFF
--- a/ITKImageProcessingFilters/ITKImageWriter.cpp
+++ b/ITKImageProcessingFilters/ITKImageWriter.cpp
@@ -49,7 +49,7 @@
 #include <itkImageFileWriter.h>
 #include <itkImageIOFactory.h>
 #include <itkMetaImageIOFactory.h>
-#include <itkNRRDImageIOFactory.h>
+#include <itkNrrdImageIOFactory.h>
 #include <itkPNGImageIOFactory.h>
 
 // ITK-SCIFIO


### PR DESCRIPTION
The case of the file name was wrong. It does not matter on Windows but it does
on Linux.
