### PR TITLE
ENH: Addition of the extension BMP

### DIFF
--- a/ITKImageProcessingPlugin.cpp
+++ b/ITKImageProcessingPlugin.cpp
@@ -126,7 +126,7 @@ QStringList ITKImageProcessingPlugin::getList3DSupportedFileExtensions()
 QStringList ITKImageProcessingPlugin::getList2DSupportedFileExtensions()
 {
   QStringList supportedExtensions;
-  supportedExtensions << ".png" << ".tif" << ".jpg" << ".jpeg";
+  supportedExtensions << ".png" << ".tif" << ".jpg" << ".jpeg" << ".bmp";
   return supportedExtensions;
 }
 

--- a/Test/ITKImageProcessingWriterTest.cpp
+++ b/Test/ITKImageProcessingWriterTest.cpp
@@ -475,6 +475,11 @@ class ITKImageProcessingWriterTest
     listJPGPixelTypes << "uint8_t" ;
     DREAM3D_REGISTER_TEST(TestWriteImage<2>("jpg", listJPGPixelTypes));
 
+    // BMP
+    QStringList listBMPPixelTypes;
+    listBMPPixelTypes << "uint8_t" ;
+    DREAM3D_REGISTER_TEST(TestWriteImage<2>("bmp", listBMPPixelTypes));
+
     // Test image series
     DREAM3D_REGISTER_TEST(TestWriteImageSeries())
 


### PR DESCRIPTION
The file extension BMP is now handled by default in
the file browser. Previously, one had to switch the type
of file to "_._" to be able to select a BMP file.
