### PR TITLE
ENH: Automatic detection of supported extensions

### DIFF
--- a/ITKImageProcessingPlugin.cpp
+++ b/ITKImageProcessingPlugin.cpp
@@ -105,19 +105,21 @@ ITKImageProcessingPlugin::~ITKImageProcessingPlugin()
 // -----------------------------------------------------------------------------
 QString ITKImageProcessingPlugin::getListSupportedFileExtensions()
 {
-  QStringList supportedExtensions = ITKImageProcessingPlugin::getList2DSupportedFileExtensions();
-  supportedExtensions += ITKImageProcessingPlugin::getList3DSupportedFileExtensions();
-  return "*" + supportedExtensions.join(" *");
-}
-
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-QStringList ITKImageProcessingPlugin::getList3DSupportedFileExtensions()
-{
   QStringList supportedExtensions;
-  supportedExtensions << ".mhd" << ".mha" << ".nrrd" << ".nhdr" << ".nii" << ".nii.gz" << ".gipl" << ".gipl.gz" << ".hdr";
-  return supportedExtensions;
+  std::list< itk::LightObject::Pointer > allobjects = itk::ObjectFactoryBase::CreateAllInstance("itkImageIOBase");
+  if (allobjects.size() > 0)
+  {
+    for (std::list< itk::LightObject::Pointer >::iterator ii = allobjects.begin(); ii != allobjects.end(); ++ii)
+    {
+      itk::ImageIOBase *io = dynamic_cast< itk::ImageIOBase * >(ii->GetPointer());
+      itk::ImageIOBase::ArrayOfExtensionsType currentExtensions = io->GetSupportedWriteExtensions();
+      for (size_t jj = 0; jj < currentExtensions.size(); jj++)
+      {
+        supportedExtensions << currentExtensions[jj].c_str();
+      }
+    }
+  }
+  return "*" + supportedExtensions.join(" *");
 }
 
 // -----------------------------------------------------------------------------

--- a/ITKImageProcessingPlugin.h
+++ b/ITKImageProcessingPlugin.h
@@ -58,11 +58,6 @@ class ITKImageProcessingPlugin : public QObject, public ISIMPLibPlugin
     static QString getListSupportedFileExtensions();
 
     /**
-    * @brief get list of supported file extensions as QStringList
-    */
-    static QStringList getList3DSupportedFileExtensions();
-
-    /**
     * @brief get list of supported 2D file extensions as QStringList
     */
     static QStringList getList2DSupportedFileExtensions();


### PR DESCRIPTION
Supported extensions were hardcoded in plugin source
code. To avoid inconsistencies when adding or removing registration
of IOs to the factory, the list of supported format is
automatically generated.
