### PR TITLE
COMP: Hiding warnings due to inconsistent-missing-override in manual …

### DIFF
--- a/ITKImageProcessingFilters/ITKBinaryThreshold.h
+++ b/ITKImageProcessingFilters/ITKBinaryThreshold.h
@@ -5,6 +5,9 @@
 #ifndef _ITKBinaryThreshold_h_
 #define _ITKBinaryThreshold_h_
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winconsistent-missing-override"
+
 #include "ITKImageBase.h"
 
 #include "SIMPLib/SIMPLib.h"
@@ -97,5 +100,7 @@ class ITKBinaryThreshold : public ITKImageBase
     ITKBinaryThreshold(const ITKBinaryThreshold&); // Copy Constructor Not Implemented
     void operator=(const ITKBinaryThreshold&); // Operator '=' Not Implemented
 };
+
+#pragma clang diagnostic pop
 
 #endif /* _ITKBinaryThreshold_H_ */

--- a/ITKImageProcessingFilters/ITKGaussianBlur.h
+++ b/ITKImageProcessingFilters/ITKGaussianBlur.h
@@ -5,6 +5,9 @@
 #ifndef _ITKGaussianBlur_h_
 #define _ITKGaussianBlur_h_
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winconsistent-missing-override"
+
 #include "SIMPLib/SIMPLib.h"
 #include "SIMPLib/Common/SIMPLibSetGetMacros.h"
 
@@ -95,5 +98,7 @@ class ITKGaussianBlur : public ITKImageBase
     ITKGaussianBlur(const ITKGaussianBlur&); // Copy Constructor Not Implemented
     void operator=(const ITKGaussianBlur&); // Operator '=' Not Implemented
 };
+
+#pragma clang diagnostic pop
 
 #endif /* _ITKGaussianBlur_H_ */


### PR DESCRIPTION
…filters

The function "IsA()" is not declared as 'override' in SIMPLibSetGetMacros.h
in SIMPL [1]. The creates a lot of warnings when compiling ITKImageProcessing.
Following the example of DREAM3D, this commit hides these warnings.

[1] https://github.com/BlueQuartzSoftware/SIMPL/commit/405fc1a6e1246e1b9112f7614e16ae44b6a4fc0b