### PR TITLE
BUG: Remove extra 'typename'

### DIFF
--- a/ITKImageProcessingFilters/Dream3DTemplateAliasMacro.h
+++ b/ITKImageProcessingFilters/Dream3DTemplateAliasMacro.h
@@ -111,9 +111,9 @@
 // 3 possible pixel type: C-type, InputImageType, and TImageType
 #define DefineInputImageType0(typeIN, dimension) // Do nothing, no type to defined
 #define DefineInputImageType1(typeIN, dimension) \
-  typedef typename itk::Dream3DImage<typeIN, dimension> InputImageType;
+  typedef itk::Dream3DImage<typeIN, dimension> InputImageType;
 #define DefineInputImageType2(typeIN, dimension) \
-  typedef typename itk::Dream3DImage<typeIN, dimension> TImageType;
+  typedef itk::Dream3DImage<typeIN, dimension> TImageType;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////
 //                                    Handles vector images                                  //


### PR DESCRIPTION
Some of the auto-generated filters produce this compile error on MSVC12 [1]:

MSVC error C2899: typename cannot be used outside a template declaration

[1] https://github.com/BlueQuartzSoftware/ITKImageProcessing/issues/37