### PR TITLE
ENH: Move Review filters to appropriate category

### DIFF
--- a/ITKImageProcessingFilters/ITKRegionalMaximaImage.cpp
+++ b/ITKImageProcessingFilters/ITKRegionalMaximaImage.cpp
@@ -161,6 +161,6 @@ const QString ITKRegionalMaximaImage::getHumanLabel()
 //
 // -----------------------------------------------------------------------------
 const QString ITKRegionalMaximaImage::getSubGroupName()
-{ return "ITK Review"; }
+{ return "ITK MathematicalMorphology"; }
 
 

--- a/ITKImageProcessingFilters/ITKRegionalMinimaImage.cpp
+++ b/ITKImageProcessingFilters/ITKRegionalMinimaImage.cpp
@@ -161,6 +161,6 @@ const QString ITKRegionalMinimaImage::getHumanLabel()
 //
 // -----------------------------------------------------------------------------
 const QString ITKRegionalMinimaImage::getSubGroupName()
-{ return "ITK Review"; }
+{ return "ITK MathematicalMorphology"; }
 
 

--- a/ITKImageProcessingFilters/ITKValuedRegionalMaximaImage.cpp
+++ b/ITKImageProcessingFilters/ITKValuedRegionalMaximaImage.cpp
@@ -149,6 +149,6 @@ const QString ITKValuedRegionalMaximaImage::getHumanLabel()
 //
 // -----------------------------------------------------------------------------
 const QString ITKValuedRegionalMaximaImage::getSubGroupName()
-{ return "ITK Review"; }
+{ return "ITK MathematicalMorphology"; }
 
 

--- a/ITKImageProcessingFilters/ITKValuedRegionalMinimaImage.cpp
+++ b/ITKImageProcessingFilters/ITKValuedRegionalMinimaImage.cpp
@@ -149,6 +149,6 @@ const QString ITKValuedRegionalMinimaImage::getHumanLabel()
 //
 // -----------------------------------------------------------------------------
 const QString ITKValuedRegionalMinimaImage::getSubGroupName()
-{ return "ITK Review"; }
+{ return "ITK MathematicalMorphology"; }
 
 


### PR DESCRIPTION
ITK review module is a place-holder while the filters are under consideration
for approval. It does not characterize what type of processing the filter does.
Filters belonging to this module are manually updated to be sorted correctly.