### PR TITLE
ENH: Add an option to testing script to keep docker image once tests …

### DIFF
--- a/Test/Docker/run.sh
+++ b/Test/Docker/run.sh
@@ -7,8 +7,22 @@ if test -z "$data_container"; then
   data_container=$(docker create --name dream3d-data dream3d/data)
 fi
 
+remove="--rm"
+while [[ $# -gt 0 ]]
+do
+key="$1"
+case $key in
+    -k|--keep)
+    remove=""
+    ;;
+    *)
+            # unknown option
+    ;;
+esac
+shift # past argument or value
+done
 docker run \
-  --rm \
+  $remove \
   --volumes-from $data_container \
   -v $script_dir/../..:/usr/src/DREAM3D/DREAM3D/Source/Plugins/ITKImageProcessing \
   dream3d/dream3d \


### PR DESCRIPTION
…are done

By default, the docker image needs to be removed after the tests are run.
However, when debugging, it is convenient to have access to the docker image.
A command line option "-k/--keep" is added to run.sh to not remove the
docker image used to run the tests.