### PR TITLE
BUG: Python script accepts float variables for filter

### DIFF
--- a/Utilities/SimpleITKJSONDream3DFilterCreation.py
+++ b/Utilities/SimpleITKJSONDream3DFilterCreation.py
@@ -167,7 +167,7 @@ tests_settings={
 
 Dream3DTypeToMacro={
   'double':{'include':'SIMPLib/FilterParameters/DoubleFilterParameter.h', 'macro':'SIMPL_NEW_DOUBLE_FP','component':'double','read':'readValue'},
-  'float':{'include':'SIMPLib/FilterParameters/FloatFilterParameter.h','macro':'SIMPL_NEW_INTEGER_FP','component':'float','read':'readValue'},
+  'float':{'include':'SIMPLib/FilterParameters/FloatFilterParameter.h','macro':'SIMPL_NEW_FLOAT_FP','component':'float','read':'readValue'},
   'int':{'include':'SIMPLib/FilterParameters/IntFilterParameter.h','macro':'SIMPL_NEW_INTEGER_FP','component':'int','read':'readValue'},
   'bool':{'include':'SIMPLib/FilterParameters/BooleanFilterParameter.h','macro':'SIMPL_NEW_BOOL_FP','component':'bool','read':'readValue'},
   'FloatVec3_t':{'include':'SIMPLib/FilterParameters/FloatVec3FilterParameter.h','macro':'SIMPL_NEW_FLOAT_VEC3_FP','component':'float','read':'readFloatVec3'},


### PR DESCRIPTION
DREAM3D used to not have a float input parameter type. Instead, the script
should have been using the DREAM3D double parameter type. There was a bug
and it was using the DREAM3D integer parameter type for floats.