### PR TITLE
COMP: Remove unnecessary typename in ImageStackTest

### DIFF
--- a/Test/ITKImageProcessingImportImageStackTest.cpp
+++ b/Test/ITKImageProcessingImportImageStackTest.cpp
@@ -80,7 +80,7 @@ class ITKImageProcessingImportImageStackTest
   void WriteTestFile(const QString& filePath, ImageType * image)
   {
     typedef itk::ImageFileWriter<ImageType> WriterType;
-    typename WriterType::Pointer writer = WriterType::New();
+    WriterType::Pointer writer = WriterType::New();
     writer->SetFileName(filePath.toStdString());
     writer->SetInput(image);
     writer->Update();


### PR DESCRIPTION
For:

  C:\Dashboards\DREAM3D_Plugins\ItkImageProcessing\Test\ITKImageProcessingImportImageStackTest.cpp(83)
  : error C2899: typename cannot be used outside a template declaration

Issue #63