### PR TITLE
ENH: Adding Cast filter

### DIFF
--- a/Documentation/ITKImageProcessingFilters/ITKCastImage.md
+++ b/Documentation/ITKImageProcessingFilters/ITKCastImage.md
@@ -1,0 +1,30 @@
+ITKCastImage {#itkcastimage}
+=============
+
+## Group (Subgroup) ##
+ITKImageFilterBase (ITKImageFilterBase)
+
+## Description ##
+This **Filter** casts input pixels to output pixel type. 
+
+## Required Geometry ##
+Image
+
+## Required Objects ##
+| Kind | Default Name | Type | Component Dimensions | Description |
+|------|--------------|-------------|---------|-----|
+| **Cell Attribute Array** | None | N/A | N/A  | Array containing input image
+
+## Created Objects ##
+| Kind | Default Name | Type | Component Dimensions | Description |
+|------|--------------|-------------|---------|-----|
+| **Cell Attribute Array** | None | N/A | N/A  | Array containing casted image
+
+## License & Copyright ##
+
+Please see the description file distributed with this plugin.
+
+## DREAM3D Mailing Lists ##
+
+If you need more help with a filter, please consider asking your question on the DREAM3D Users mailing list:
+https://groups.google.com/forum/?hl=en#!forum/dream3d-users

--- a/ITKImageProcessingFilters/Dream3DTemplateAliasMacro.h
+++ b/ITKImageProcessingFilters/Dream3DTemplateAliasMacro.h
@@ -22,7 +22,7 @@
 #include "SIMPLib/Common/AbstractFilter.h"
 #include <itkVector.h>
 #include <itkRGBAPixel.h>
-
+#include <itkImageIOBase.h>
 
 // Allow individual switching of support for each scalar size/signedness.
 // These could be made advanced user options to be configured by CMake.
@@ -229,5 +229,48 @@
 // type as the input data array.
 #define Dream3DArraySwitchMacro(call, path, errorCondition) \
   Dream3DArraySwitchMacroLongOutputType(call, path, errorCondition, "", 0, 0)
+
+// Define macro to select the output image component type.
+// Subtract 1 to enum values because 'type' values are expected to start at 0 while
+// itk::ImageIOBase::IOComponentType '0' value is UNKNOWNCOMPONENTTYPE and therefore
+// should be skipped.
+#define Dream3DArraySwitchOutputComponentMacro(call, type, path, errorCondition) \
+   switch(type)\
+   {\
+     case itk::ImageIOBase::IOComponentType::UCHAR-1:\
+             Dream3DArraySwitchMacroOutputType(call, path, -4,uint8_t,0);\
+             break;\
+     case itk::ImageIOBase::IOComponentType::CHAR-1:\
+             Dream3DArraySwitchMacroOutputType(call, path, -4,int8_t,0);\
+             break;\
+     case itk::ImageIOBase::IOComponentType::USHORT-1:\
+             Dream3DArraySwitchMacroOutputType(call, path, -4,uint16_t,0);\
+             break;\
+     case itk::ImageIOBase::IOComponentType::SHORT-1:\
+             Dream3DArraySwitchMacroOutputType(call, path, -4,int16_t,0);\
+             break;\
+     case itk::ImageIOBase::IOComponentType::UINT-1:\
+             Dream3DArraySwitchMacroOutputType(call, path, -4,uint32_t,0);\
+             break;\
+     case itk::ImageIOBase::IOComponentType::INT-1:\
+             Dream3DArraySwitchMacroOutputType(call, path, -4,int32_t,0);\
+             break;\
+     case itk::ImageIOBase::IOComponentType::ULONG-1:\
+             Dream3DArraySwitchMacroOutputType(call, path, -4,uint64_t,0);\
+             break;\
+     case itk::ImageIOBase::IOComponentType::LONG-1:\
+             Dream3DArraySwitchMacroOutputType(call, path, -4,int64_t,0);\
+             break;\
+     case itk::ImageIOBase::IOComponentType::FLOAT-1:\
+             Dream3DArraySwitchMacroOutputType(call, path, -4,float,0);\
+             break;\
+     case itk::ImageIOBase::IOComponentType::DOUBLE-1:\
+             Dream3DArraySwitchMacroOutputType(call, path, -4,double,0);\
+             break;\
+     default:\
+             setErrorCondition(-4);\
+             notifyErrorMessage(getHumanLabel(), "Unsupported pixel component", errorCondition);\
+             break;\
+   }
 
 #endif

--- a/ITKImageProcessingFilters/ITKCastImage.cpp
+++ b/ITKImageProcessingFilters/ITKCastImage.cpp
@@ -1,0 +1,178 @@
+/*
+ * Your License or Copyright can go here
+ */
+
+#include "ITKCastImage.h"
+
+#include "SIMPLib/Common/Constants.h"
+#include "SIMPLib/FilterParameters/AbstractFilterParametersReader.h"
+#include "SIMPLib/FilterParameters/DataArraySelectionFilterParameter.h"
+#include "SIMPLib/FilterParameters/StringFilterParameter.h"
+#include "SIMPLib/FilterParameters/LinkedBooleanFilterParameter.h"
+#include "SIMPLib/FilterParameters/SeparatorFilterParameter.h"
+#include "SIMPLib/FilterParameters/ChoiceFilterParameter.h"
+#include "SIMPLib/Geometry/ImageGeom.h"
+
+
+#include "ITKImageProcessing/ITKImageProcessingFilters/itkDream3DImage.h"
+#include "ITKImageProcessing/ITKImageProcessingFilters/Dream3DTemplateAliasMacro.h"
+
+// Include the MOC generated file for this class
+#include "moc_ITKCastImage.cpp"
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+ITKCastImage::ITKCastImage() :
+  ITKImageBase()
+  , m_CastingType(itk::ImageIOBase::IOComponentType::UCHAR-1)
+{
+  setupFilterParameters();
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+ITKCastImage::~ITKCastImage()
+{
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void ITKCastImage::setupFilterParameters()
+{
+  FilterParameterVector parameters;
+
+  {
+    ChoiceFilterParameter::Pointer parameter = ChoiceFilterParameter::New();
+    parameter->setHumanLabel("Casting Type");
+    parameter->setPropertyName("CastingType");
+    parameter->setSetterCallback(SIMPL_BIND_SETTER(ITKCastImage, this, CastingType));
+    parameter->setGetterCallback(SIMPL_BIND_GETTER(ITKCastImage, this, CastingType));
+
+    QVector<QString> choices;
+    choices.push_back("unsigned char");
+    choices.push_back("char");
+    choices.push_back("unsigned short");
+    choices.push_back("short");
+    choices.push_back("unsigned int");
+    choices.push_back("int");
+    choices.push_back("unsigned long");
+    choices.push_back("long");
+    choices.push_back("float");
+    choices.push_back("double");
+    parameter->setChoices(choices);
+    parameter->setCategory(FilterParameter::Parameter);
+    parameters.push_back(parameter);
+  }
+
+  QStringList linkedProps;
+  linkedProps << "NewCellArrayName";
+  parameters.push_back(SIMPL_NEW_LINKED_BOOL_FP("Save as New Array", SaveAsNewArray, FilterParameter::Parameter, ITKCastImage, linkedProps));
+  parameters.push_back(SeparatorFilterParameter::New("Cell Data", FilterParameter::RequiredArray));
+  {
+    DataArraySelectionFilterParameter::RequirementType req =
+      DataArraySelectionFilterParameter::CreateRequirement(SIMPL::Defaults::AnyPrimitive, SIMPL::Defaults::AnyComponentSize,
+      AttributeMatrix::Type::Cell, IGeometry::Type::Image);
+    parameters.push_back(SIMPL_NEW_DA_SELECTION_FP("Attribute Array to filter", SelectedCellArrayPath, FilterParameter::RequiredArray, ITKCastImage, req));
+  }
+  parameters.push_back(SeparatorFilterParameter::New("Cell Data", FilterParameter::CreatedArray));
+  parameters.push_back(SIMPL_NEW_STRING_FP("Filtered Array", NewCellArrayName, FilterParameter::CreatedArray, ITKCastImage));
+
+  setFilterParameters(parameters);
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void ITKCastImage::readFilterParameters(AbstractFilterParametersReader* reader, int index)
+{
+  reader->openFilterGroup(this, index);
+  setSelectedCellArrayPath( reader->readDataArrayPath( "SelectedCellArrayPath", getSelectedCellArrayPath() ) );
+  setNewCellArrayName( reader->readString( "NewCellArrayName", getNewCellArrayName() ) );
+  setSaveAsNewArray( reader->readValue( "SaveAsNewArray", getSaveAsNewArray() ) );
+  setCastingType(reader->readValue("CastingType", getCastingType()));
+
+  reader->closeFilterGroup();
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+template<typename InputPixelType, typename OutputPixelType, unsigned int Dimension>
+void ITKCastImage::dataCheck()
+{
+  // Check consistency of parameters
+  setErrorCondition(0);
+  typedef typename itk::NumericTraits<InputPixelType>::ValueType   InputValueType;
+  typedef typename itk::NumericTraits<OutputPixelType>::ValueType   OutputValueType;
+  if(std::numeric_limits<InputValueType>::max() > std::numeric_limits<OutputValueType>::max()
+    || std::numeric_limits<InputValueType>::lowest() < std::numeric_limits<OutputValueType>::lowest()
+    )
+  {
+    setErrorCondition(-5);
+    notifyErrorMessage(getHumanLabel(), "Boundaries values of output component type inside boundaries of input component type. Use ITK::Rescale Intensity Image Filter instead.", getErrorCondition());
+    return;
+  }    
+  ITKImageBase::dataCheck<InputPixelType, OutputPixelType, Dimension>();
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void ITKCastImage::dataCheckInternal()
+{
+   Dream3DArraySwitchOutputComponentMacro(this->dataCheck, m_CastingType, getSelectedCellArrayPath(), -4);
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+
+template<typename InputPixelType, typename OutputPixelType, unsigned int Dimension>
+void ITKCastImage::filter()
+{
+  typedef itk::Dream3DImage<InputPixelType, Dimension> InputImageType;
+  typedef itk::Dream3DImage<OutputPixelType, Dimension> OutputImageType;
+  //define filter
+  typedef itk::CastImageFilter<InputImageType, OutputImageType> FilterType;
+  typename FilterType::Pointer filter = FilterType::New();
+  this->ITKImageBase::filter<InputPixelType, OutputPixelType, Dimension, FilterType>(filter);
+
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void ITKCastImage::filterInternal()
+{
+   Dream3DArraySwitchOutputComponentMacro(this->filter, m_CastingType, getSelectedCellArrayPath(), -4);
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+AbstractFilter::Pointer ITKCastImage::newFilterInstance(bool copyFilterParameters)
+{
+  ITKCastImage::Pointer filter = ITKCastImage::New();
+  if(true == copyFilterParameters)
+  {
+    copyFilterParameterInstanceVariables(filter.get());
+  }
+  return filter;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+const QString ITKCastImage::getHumanLabel()
+{ return "ITK::Cast Image Filter (KW)"; }
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+const QString ITKCastImage::getSubGroupName()
+{ return "ITK ImageFilterBase"; }
+
+

--- a/ITKImageProcessingFilters/ITKCastImage.h
+++ b/ITKImageProcessingFilters/ITKCastImage.h
@@ -1,0 +1,98 @@
+/*
+ * Your License or Copyright can go here
+ */
+
+#ifndef _ITKCastImage_h_
+#define _ITKCastImage_h_
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winconsistent-missing-override"
+#endif
+
+#include "ITKImageBase.h"
+
+#include "SIMPLib/SIMPLib.h"
+#include "SIMPLib/Common/SIMPLibSetGetMacros.h"
+
+#include <SIMPLib/FilterParameters/BooleanFilterParameter.h>
+#include <itkCastImageFilter.h>
+
+/**
+ * @brief The ITKCastImage class. See [Filter documentation](@ref ITKCastImage) for details.
+ */
+class ITKCastImage : public ITKImageBase
+{
+  Q_OBJECT
+
+  public:
+    SIMPL_SHARED_POINTERS(ITKCastImage)
+    SIMPL_STATIC_NEW_MACRO(ITKCastImage)
+    SIMPL_TYPE_MACRO_SUPER_OVERRIDE(ITKCastImage, AbstractFilter)
+
+    SIMPL_FILTER_PARAMETER(int, CastingType)
+    Q_PROPERTY(int CastingType READ getCastingType WRITE setCastingType)
+
+    virtual ~ITKCastImage();
+
+    /**
+     * @brief newFilterInstance Reimplemented from @see AbstractFilter class
+     */
+    virtual AbstractFilter::Pointer newFilterInstance(bool copyFilterParameters) override;
+
+    /**
+     * @brief getHumanLabel Reimplemented from @see AbstractFilter class
+     */
+    virtual const QString getHumanLabel() override;
+
+    /**
+     * @brief getSubGroupName Reimplemented from @see AbstractFilter class
+     */
+    virtual const QString getSubGroupName() override;
+    
+    /**
+     * @brief setupFilterParameters Reimplemented from @see AbstractFilter class
+     */
+    virtual void setupFilterParameters() override;
+
+    /**
+     * @brief readFilterParameters Reimplemented from @see AbstractFilter class
+     */
+    virtual void readFilterParameters(AbstractFilterParametersReader* reader, int index) override;
+
+  protected:
+    ITKCastImage();
+
+    /**
+     * @brief dataCheckInternal overloads dataCheckInternal in ITKImageBase and calls templated dataCheck
+     */
+    void virtual dataCheckInternal() override;
+
+    /**
+     * @brief dataCheck Checks for the appropriate parameter values and availability of arrays
+     */
+    template<typename InputImageType, typename OutputImageType, unsigned int Dimension>
+    void dataCheck();
+
+    /**
+    * @brief filterInternal overloads filterInternal in ITKImageBase and calls templated filter
+    */
+    void virtual filterInternal() override;
+
+    /**
+    * @brief Applies the filter
+    */
+    template<typename InputImageType, typename OutputImageType, unsigned int Dimension>
+    void filter();
+
+  private:
+
+    ITKCastImage(const ITKCastImage&); // Copy Constructor Not Implemented
+    void operator=(const ITKCastImage&); // Operator '=' Not Implemented
+};
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
+#endif /* _ITKCastImage_H_ */

--- a/ITKImageProcessingFilters/ITKRescaleIntensityImage.h
+++ b/ITKImageProcessingFilters/ITKRescaleIntensityImage.h
@@ -42,7 +42,8 @@ class ITKRescaleIntensityImage : public ITKImageBase
     SIMPL_FILTER_PARAMETER(double, OutputMaximum)
     Q_PROPERTY(double OutputMaximum READ getOutputMaximum WRITE setOutputMaximum)
 
-
+    SIMPL_FILTER_PARAMETER(int, OutputType)
+    Q_PROPERTY(int OutputType READ getOutputType WRITE setOutputType)
 
     /**
      * @brief newFilterInstance Reimplemented from @see AbstractFilter class
@@ -93,6 +94,12 @@ class ITKRescaleIntensityImage : public ITKImageBase
     */
     template<typename InputImageType, typename OutputImageType, unsigned int Dimension>
     void filter();
+
+    /**
+    * @brief Checks 'value' can be casted to OutputPixelType.
+    */
+    template<typename OutputPixelType>
+    void CheckEntryBounds(double value, QString name);
 
   private:
 

--- a/ITKImageProcessingFilters/SourceList.cmake
+++ b/ITKImageProcessingFilters/SourceList.cmake
@@ -89,6 +89,7 @@ set(_PublicFilters
   ITKThresholdMaximumConnectedComponentsImage
   ITKSmoothingRecursiveGaussianImage
   ITKAdaptiveHistogramEqualizationImage
+  ITKCastImage
 )
 
 

--- a/Test/CMakeLists.txt
+++ b/Test/CMakeLists.txt
@@ -94,6 +94,7 @@ set(TEST_NAMES
   ITKThresholdMaximumConnectedComponentsImage
   ITKSmoothingRecursiveGaussianImage
   ITKAdaptiveHistogramEqualizationImage
+  ITKCastImage
   )
 
 set( ${PLUGIN_NAME}_TEST_SRCS )

--- a/Test/ITKCastImageTest.cpp
+++ b/Test/ITKCastImageTest.cpp
@@ -1,0 +1,105 @@
+// -----------------------------------------------------------------------------
+// Insert your license & copyright information here
+// -----------------------------------------------------------------------------
+
+#include "ITKTestBase.h"
+
+#include <itkImageIOBase.h>
+
+class ITKCastImageTest: public ITKTestBase
+{
+
+  public:
+    ITKCastImageTest() {}
+    virtual ~ITKCastImageTest() {}
+
+int TestITKCastImagefloatTodoubleTest()
+{
+    QString input_filename = UnitTest::DataDir + QString("/Data/JSONFilters/Input/RA-Slice-Float.nrrd");
+    DataArrayPath input_path("TestContainer", "TestAttributeMatrixName", "TestAttributeArrayName");
+    DataContainerArray::Pointer containerArray = DataContainerArray::New();
+    this->ReadImage(input_filename, containerArray, input_path);
+    QString filtName = "ITKCastImage";
+    FilterManager* fm = FilterManager::Instance();
+    IFilterFactory::Pointer filterFactory = fm->getFactoryForFilter(filtName);
+    DREAM3D_REQUIRE_NE(filterFactory.get(),0);
+    AbstractFilter::Pointer filter = filterFactory->create();
+    QVariant var;
+    bool propWasSet;
+    var.setValue(input_path);
+    propWasSet = filter->setProperty("SelectedCellArrayPath", var);
+    DREAM3D_REQUIRE_EQUAL(propWasSet, true);
+    var.setValue(false);
+    propWasSet = filter->setProperty("SaveAsNewArray", var);
+    DREAM3D_REQUIRE_EQUAL(propWasSet, true);
+    var.setValue(itk::ImageIOBase::IOComponentType::DOUBLE-1);
+    propWasSet = filter->setProperty("CastingType", var);
+    DREAM3D_REQUIRE_EQUAL(propWasSet, true);
+    filter->setDataContainerArray(containerArray);
+    filter->execute();
+    DREAM3D_REQUIRED(filter->getErrorCondition(), >= , 0);
+    DREAM3D_REQUIRED(filter->getWarningCondition(), >= , 0);
+    WriteImage("ITKCastImagefloatTodouble.nrrd", containerArray, input_path);
+    QString baseline_filename = UnitTest::DataDir + QString("/Data/JSONFilters/Baseline/BasicFilters_CastImageFilter_float_to_double.nrrd");
+    DataArrayPath baseline_path("BContainer", "BAttributeMatrixName", "BAttributeArrayName");
+    this->ReadImage(baseline_filename, containerArray, baseline_path);
+    int res = this->CompareImages(containerArray, input_path, baseline_path, 0.01);
+    DREAM3D_REQUIRE_EQUAL(res,0);
+    return 0;
+}
+
+int TestITKCastImageFailTest()
+{
+    QString input_filename = UnitTest::DataDir + QString("/Data/JSONFilters/Input/RA-Slice-Short.nrrd");
+    DataArrayPath input_path("TestContainer", "TestAttributeMatrixName", "TestAttributeArrayName");
+    DataContainerArray::Pointer containerArray = DataContainerArray::New();
+    this->ReadImage(input_filename, containerArray, input_path);
+    QString filtName = "ITKCastImage";
+    FilterManager* fm = FilterManager::Instance();
+    IFilterFactory::Pointer filterFactory = fm->getFactoryForFilter(filtName);
+    DREAM3D_REQUIRE_NE(filterFactory.get(),0);
+    AbstractFilter::Pointer filter = filterFactory->create();
+    QVariant var;
+    bool propWasSet;
+    var.setValue(input_path);
+    propWasSet = filter->setProperty("SelectedCellArrayPath", var);
+    DREAM3D_REQUIRE_EQUAL(propWasSet, true);
+    var.setValue(false);
+    propWasSet = filter->setProperty("SaveAsNewArray", var);
+    DREAM3D_REQUIRE_EQUAL(propWasSet, true);
+    var.setValue(itk::ImageIOBase::IOComponentType::UCHAR-1);
+    propWasSet = filter->setProperty("CastingType", var);
+    DREAM3D_REQUIRE_EQUAL(propWasSet, true);
+    filter->setDataContainerArray(containerArray);
+    filter->execute();
+    DREAM3D_REQUIRED(filter->getErrorCondition(), == , -5);
+    DREAM3D_REQUIRED(filter->getWarningCondition(), >= , 0);
+    return 0;
+}
+
+
+
+
+  // -----------------------------------------------------------------------------
+  //
+  // -----------------------------------------------------------------------------
+  void operator()() override
+  {
+    int err = EXIT_SUCCESS;
+
+    DREAM3D_REGISTER_TEST( this->TestFilterAvailability("ITKCastImage") );
+
+    DREAM3D_REGISTER_TEST( TestITKCastImagefloatTodoubleTest());
+    DREAM3D_REGISTER_TEST( TestITKCastImageFailTest());
+
+    if(SIMPL::unittest::numTests == SIMPL::unittest::numTestsPass)
+    {
+      DREAM3D_REGISTER_TEST( this->RemoveTestFiles() )
+    }
+  }
+
+  private:
+    ITKCastImageTest(const ITKCastImageTest&); // Copy Constructor Not Implemented
+    void operator=(const ITKCastImageTest&); // Operator '=' Not Implemented
+};
+

--- a/Test/ITKRescaleIntensityImageTest.cpp
+++ b/Test/ITKRescaleIntensityImageTest.cpp
@@ -8,6 +8,7 @@
 //Auto includes
 #include <SIMPLib/FilterParameters/DoubleFilterParameter.h>
 
+#include <itkImageIOBase.h>
 
 class ITKRescaleIntensityImageTest: public ITKTestBase
 {
@@ -34,6 +35,9 @@ int TestITKRescaleIntensityImage3dTest()
     DREAM3D_REQUIRE_EQUAL(propWasSet, true);
     var.setValue(false);
     propWasSet = filter->setProperty("SaveAsNewArray", var);
+    DREAM3D_REQUIRE_EQUAL(propWasSet, true);
+    var.setValue(itk::ImageIOBase::IOComponentType::FLOAT-1);
+    propWasSet = filter->setProperty("OutputType", var);
     DREAM3D_REQUIRE_EQUAL(propWasSet, true);
     filter->setDataContainerArray(containerArray);
     filter->execute();


### PR DESCRIPTION
Cast filter allows to convert component types from one type to another. This
filter limits casting from an input type to an output type that can contain
all the values of the input type. This limitation will avoid having users
being surprised by the result of casting from, for example, float to char
which creates an results image that may not look like expected.