### PR TITLE
BUG: On Windows, DREAM3D executable in not in a subdirectory bin

### DIFF
--- a/ITKImageProcessingPlugin.cpp
+++ b/ITKImageProcessingPlugin.cpp
@@ -111,7 +111,9 @@ ITKImageProcessingPlugin::~ITKImageProcessingPlugin()
 void ITKImageProcessingPlugin::setSCIFIOEnvironmentVariables()
 {
   QFileInfo fi = QFileInfo(QCoreApplication::applicationDirPath());
-  QString applicationDir = fi.absolutePath();
+  #ifndef WIN32
+  QString applicationDir = fi.absolutePath(); // Goes up one directory (bin/..)
+  #endif
   std::string SCIFIO_PATH = std::string("SCIFIO_PATH=")+applicationDir.toStdString()+"/lib/jars";
   itksys::SystemTools::PutEnv(SCIFIO_PATH);
   std::string JAVA_HOME = std::string("JAVA_HOME=")+applicationDir.toStdString()+"/lib/jre";


### PR DESCRIPTION
When setting paths for SCIFIO to find jars and jre, only go up one directory
if DREAM3D is running on a "not Windows" system. On these systems, the
executable is installed in the 'bin' subfolder whereas on Windows the
DREAM3D executable is installed directly in the main DREAM3D folder.