### PR TITLE
ENH: Improve Dream3DTemplateAliasMacro.h

### DIFF
--- a/ITKImageProcessingFilters/ITKImageWriter.cpp
+++ b/ITKImageProcessingFilters/ITKImageWriter.cpp
@@ -44,11 +44,9 @@
 #include "ITKImageProcessing/ITKImageProcessingConstants.h"
 #include "ITKImageProcessing/ITKImageProcessingVersion.h"
 #include "ITKImageProcessingPlugin.h"
-#include "ITKImageProcessing/ITKImageProcessingFilters/Dream3DTemplateAliasMacro.h"
-#undef DREAM3D_USE_RGBA
 #define DREAM3D_USE_RGBA 1
-#undef DREAM3D_USE_Vector
 #define DREAM3D_USE_Vector 1
+#include "ITKImageProcessing/ITKImageProcessingFilters/Dream3DTemplateAliasMacro.h"
 
 // ITK includes
 #include <itkImageFileWriter.h>

--- a/ITKImageProcessingFilters/ITKSaltAndPepperNoiseImage.cpp
+++ b/ITKImageProcessingFilters/ITKSaltAndPepperNoiseImage.cpp
@@ -18,9 +18,8 @@
 
 
 #include "ITKImageProcessing/ITKImageProcessingFilters/itkDream3DImage.h"
-#include "ITKImageProcessing/ITKImageProcessingFilters/Dream3DTemplateAliasMacro.h"
-#undef DREAM3D_USE_RGBA
 #define DREAM3D_USE_RGBA 1
+#include "ITKImageProcessing/ITKImageProcessingFilters/Dream3DTemplateAliasMacro.h"
 // Include the MOC generated file for this class
 #include "moc_ITKSaltAndPepperNoiseImage.cpp"
 

--- a/ITKImageProcessingFilters/ITKSmoothingRecursiveGaussianImage.cpp
+++ b/ITKImageProcessingFilters/ITKSmoothingRecursiveGaussianImage.cpp
@@ -18,9 +18,8 @@
 
 
 #include "ITKImageProcessing/ITKImageProcessingFilters/itkDream3DImage.h"
-#include "ITKImageProcessing/ITKImageProcessingFilters/Dream3DTemplateAliasMacro.h"
-#undef DREAM3D_USE_RGBA
 #define DREAM3D_USE_RGBA 1
+#include "ITKImageProcessing/ITKImageProcessingFilters/Dream3DTemplateAliasMacro.h"
 
 // Include the MOC generated file for this class
 #include "moc_ITKSmoothingRecursiveGaussianImage.cpp"


### PR DESCRIPTION
Improve documentation

Allow disabling scalar pixel type support.

Instead of defining values in Dream3DTemplateAliasMacro.h for supported types
and then redefining them to a different value if necessary, define types
before including Dream3DTemplateAliasMacro.h .