### PR TITLE
COMP: RGBToLuminance remove unused typedef

### DIFF
--- a/ITKImageProcessingFilters/ITKRGBToLuminanceImage.cpp
+++ b/ITKImageProcessingFilters/ITKRGBToLuminanceImage.cpp
@@ -104,7 +104,6 @@ void ITKRGBToLuminanceImage::dataCheckInternal()
 template<typename InputPixelType, typename OutputPixelType, unsigned int Dimension>
 void ITKRGBToLuminanceImage::filter()
 {
-  typedef itk::Dream3DImage<InputPixelType, Dimension>                    InputImageType;
   typedef typename itk::NumericTraits< InputPixelType >::ValueType        ScalarPixelType;
   typedef itk::Dream3DImage< ScalarPixelType, Dimension >                 OutputImageType;
 


### PR DESCRIPTION
To address:

  DREAM3D_Plugins/ITKImageProcessing/ITKImageProcessingFilters/ITKRGBToLuminanceImage.cpp:107:75:
  warning: unused typedef 'InputImageType' [-Wunused-local-typedef]