### PR TITLE
BUG: The number of components of the output image is based on the out…

### DIFF
--- a/ITKImageProcessingFilters/ITKImageBase.h
+++ b/ITKImageProcessingFilters/ITKImageBase.h
@@ -193,8 +193,8 @@ class ITKImageBase : public AbstractFilter
 
       DataArrayPath tempPath;
 
-      QVector<size_t> dims = ITKDream3DHelper::GetComponentsDimensions<InputPixelType>();
-      selectedCellArrayPtr = getDataContainerArray()->getPrereqArrayFromPath<DataArray<InputValueType>, AbstractFilter>(this, getSelectedCellArrayPath(), dims); /* Assigns the shared_ptr<> to an instance variable that is a weak_ptr<> */
+      QVector<size_t> inputDims = ITKDream3DHelper::GetComponentsDimensions<InputPixelType>();
+      selectedCellArrayPtr = getDataContainerArray()->getPrereqArrayFromPath<DataArray<InputValueType>, AbstractFilter>(this, getSelectedCellArrayPath(), inputDims); /* Assigns the shared_ptr<> to an instance variable that is a weak_ptr<> */
       if (nullptr != selectedCellArrayPtr.lock().get()) /* Validate the Weak Pointer wraps a non-nullptr pointer to a DataArray<T> object */
       {
         selectedCellArray = selectedCellArrayPtr.lock()->getPointer(0);
@@ -203,11 +203,11 @@ class ITKImageBase : public AbstractFilter
 
       ImageGeom::Pointer image = getDataContainerArray()->getDataContainer(getSelectedCellArrayPath().getDataContainerName())->getPrereqGeometry<ImageGeom, AbstractFilter>(this);
       if (getErrorCondition() < 0 || nullptr == image.get()) { return; }
-
+      QVector<size_t> outputDims = ITKDream3DHelper::GetComponentsDimensions<OutputPixelType>();
       if (m_SaveAsNewArray == true)
       {
         tempPath.update(getSelectedCellArrayPath().getDataContainerName(), getSelectedCellArrayPath().getAttributeMatrixName(), getNewCellArrayName());
-        m_NewCellArrayPtr = getDataContainerArray()->createNonPrereqArrayFromPath<DataArray<OutputValueType>, AbstractFilter, OutputValueType>(this, tempPath, 0, dims); /* Assigns the shared_ptr<> to an instance variable that is a weak_ptr<> */
+        m_NewCellArrayPtr = getDataContainerArray()->createNonPrereqArrayFromPath<DataArray<OutputValueType>, AbstractFilter, OutputValueType>(this, tempPath, 0, outputDims); /* Assigns the shared_ptr<> to an instance variable that is a weak_ptr<> */
         if (nullptr != m_NewCellArrayPtr.lock().get()) /* Validate the Weak Pointer wraps a non-nullptr pointer to a DataArray<T> object */
         {
           m_NewCellArray = m_NewCellArrayPtr.lock()->getVoidPointer(0);

--- a/ITKImageProcessingFilters/ITKRGBToLuminanceImage.cpp
+++ b/ITKImageProcessingFilters/ITKRGBToLuminanceImage.cpp
@@ -14,6 +14,7 @@
 #include "SIMPLib/Geometry/ImageGeom.h"
 
 #define DREAM3D_USE_RGBA 1
+#define DREAM3D_USE_Scalar 0
 #include "ITKImageProcessing/ITKImageProcessingFilters/itkDream3DImage.h"
 #include "ITKImageProcessing/ITKImageProcessingFilters/Dream3DTemplateAliasMacro.h"
 
@@ -44,7 +45,6 @@ void ITKRGBToLuminanceImage::setupFilterParameters()
   FilterParameterVector parameters;
   QStringList linkedProps;
   linkedProps << "NewCellArrayName";
-  parameters.push_back(SIMPL_NEW_LINKED_BOOL_FP("Save as New Array", SaveAsNewArray, FilterParameter::Parameter, ITKRGBToLuminanceImage, linkedProps));
   parameters.push_back(SeparatorFilterParameter::New("Cell Data", FilterParameter::RequiredArray));
   {
     DataArraySelectionFilterParameter::RequirementType req =
@@ -86,7 +86,8 @@ void ITKRGBToLuminanceImage::dataCheck()
     notifyErrorMessage(getHumanLabel(), "Input image pixels should have three (RGB) or four (RGBA) components.", getErrorCondition());
     return;
   }
-  ITKImageBase::dataCheck<InputPixelType, OutputPixelType, Dimension>();
+  typedef typename itk::NumericTraits< InputPixelType >::ValueType        ScalarPixelType;
+  ITKImageBase::dataCheck<InputPixelType, ScalarPixelType, Dimension>();
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
…put pixel type

Previously, in the preflight step, the number of components of the output image was
computed based on the input pixel type. This addresses [1].

WARNING: If a filter uses input and output pixel types that have different number
of components, a new array is required. The boolean checkbox to select if a new
array should be used should be hidden. By default, this boolean variable is
set to 'true' in ITKImageBase constructor.

[1] https://github.com/BlueQuartzSoftware/ITKImageProcessing/issues/114