### PR TITLE
BUG: Create an output array with desired components

### DIFF
--- a/ITKImageProcessingFilters/itkInPlaceImageToDream3DDataFilter.hxx
+++ b/ITKImageProcessingFilters/itkInPlaceImageToDream3DDataFilter.hxx
@@ -171,9 +171,12 @@ InPlaceImageToDream3DDataFilter<PixelType, VDimension>
   }
   else
   {
-      //This code needs to be updated to take into accound the rank and dimensions of the tuples
-    data = DataArrayPixelType::FromPointer(reinterpret_cast<ValueType*>(inputPtr->GetBufferPointer()),
-              imageGeom->getNumberOfElements(), m_DataArrayName.c_str(), true);
+    data = DataArrayPixelType::CreateArray(imageGeom->getNumberOfElements(), cDims,
+              m_DataArrayName.c_str(), true);
+    if (nullptr != data.get())
+    {
+      ::memcpy(data->getPointer(0), reinterpret_cast<ValueType*>(inputPtr->GetBufferPointer()), imageGeom->getNumberOfElements() * sizeof(ValueType));
+    }
   }
   attrMat->addAttributeArray(m_DataArrayName.c_str(), data);
   outputPtr->Set(dataContainer);


### PR DESCRIPTION
When creating a new Dream3D data array from an ITK Image, and that Image has
multiple dimensions, e.g. with an RGB pixel, specify the rank in
itk::InPlaceImageToDream3DDataFilter.