### PR TITLE
ENH: Addition of support for RGB pixels

### DIFF
--- a/ITKImageProcessingFilters/ITKImageReader.cpp
+++ b/ITKImageProcessingFilters/ITKImageReader.cpp
@@ -187,8 +187,10 @@ void ITKImageReader::readImage(itk::ImageIOBase::IOPixelType pixel, const QStrin
         readImage<TComponent,dimensions>(filename, dataCheck);
         break;
     case itk::ImageIOBase::RGBA:
-    case itk::ImageIOBase::RGB:
         readImage<itk::RGBAPixel<TComponent>,dimensions >(filename, dataCheck);
+        break;
+    case itk::ImageIOBase::RGB:
+        readImage<itk::RGBPixel<TComponent>,dimensions >(filename, dataCheck);
         break;
     case itk::ImageIOBase::VECTOR:
         readImage<itk::Vector<TComponent,dimensions>,dimensions>(filename, dataCheck);

--- a/ITKImageProcessingFilters/ITKImageWriter.cpp
+++ b/ITKImageProcessingFilters/ITKImageWriter.cpp
@@ -46,7 +46,7 @@
 #include "ITKImageProcessing/ITKImageProcessingConstants.h"
 #include "ITKImageProcessing/ITKImageProcessingVersion.h"
 #include "ITKImageProcessingPlugin.h"
-#define DREAM3D_USE_RGBA 1
+#define DREAM3D_USE_RGB_RGBA 1
 #define DREAM3D_USE_Vector 1
 #include "ITKImageProcessing/ITKImageProcessingFilters/Dream3DTemplateAliasMacro.h"
 

--- a/ITKImageProcessingFilters/ITKRGBToLuminanceImage.cpp
+++ b/ITKImageProcessingFilters/ITKRGBToLuminanceImage.cpp
@@ -13,7 +13,7 @@
 #include "SIMPLib/FilterParameters/ChoiceFilterParameter.h"
 #include "SIMPLib/Geometry/ImageGeom.h"
 
-#define DREAM3D_USE_RGBA 1
+#define DREAM3D_USE_RGB_RGBA 1
 #define DREAM3D_USE_Scalar 0
 #include "ITKImageProcessing/ITKImageProcessingFilters/itkDream3DImage.h"
 #include "ITKImageProcessing/ITKImageProcessingFilters/Dream3DTemplateAliasMacro.h"

--- a/ITKImageProcessingFilters/ITKSaltAndPepperNoiseImage.cpp
+++ b/ITKImageProcessingFilters/ITKSaltAndPepperNoiseImage.cpp
@@ -18,7 +18,7 @@
 
 
 #include "ITKImageProcessing/ITKImageProcessingFilters/itkDream3DImage.h"
-#define DREAM3D_USE_RGBA 1
+#define DREAM3D_USE_RGB_RGBA 1
 #include "ITKImageProcessing/ITKImageProcessingFilters/Dream3DTemplateAliasMacro.h"
 // Include the MOC generated file for this class
 #include "moc_ITKSaltAndPepperNoiseImage.cpp"

--- a/ITKImageProcessingFilters/ITKSmoothingRecursiveGaussianImage.cpp
+++ b/ITKImageProcessingFilters/ITKSmoothingRecursiveGaussianImage.cpp
@@ -18,7 +18,7 @@
 
 
 #include "ITKImageProcessing/ITKImageProcessingFilters/itkDream3DImage.h"
-#define DREAM3D_USE_RGBA 1
+#define DREAM3D_USE_RGB_RGBA 1
 #include "ITKImageProcessing/ITKImageProcessingFilters/Dream3DTemplateAliasMacro.h"
 
 // Include the MOC generated file for this class

--- a/ITKImageProcessingFilters/itkGetComponentsDimensions.h
+++ b/ITKImageProcessingFilters/itkGetComponentsDimensions.h
@@ -1,6 +1,7 @@
 #ifndef _ITKGetComponentsDimensions_h
 #define _ITKGetComponentsDimensions_h
 
+#include <itkRGBPixel.h>
 #include <itkRGBAPixel.h>
 #include <itkVector.h>
 #include <QVector>
@@ -26,6 +27,13 @@ namespace ITKDream3DHelper
   QVector<size_t> GetComponentsDimensions_impl(itk::Vector<PixelType,2>*)
   {
     QVector<size_t> cDims(2, 1);
+    return cDims;
+  }
+
+  template<class PixelType>
+  QVector<size_t> GetComponentsDimensions_impl(itk::RGBPixel<PixelType>*)
+  {
+    QVector<size_t> cDims(1, 3);
     return cDims;
   }
 

--- a/Test/ITKImageProcessingImageTest.cpp
+++ b/Test/ITKImageProcessingImageTest.cpp
@@ -121,7 +121,7 @@ class ITKImageProcessingImageTest
     duplicator->SetInputImage(image);
     duplicator->Update();
     typename ImageType::Pointer clonedImage = duplicator->GetOutput();
-    // Convert RGBA image to DREAM.3D data
+    // Convert image to DREAM.3D data
     DataArrayPath path("DataContainer","AttributeMatrix","DataArray");
     DataContainer::Pointer container = DataContainer::New(path.getDataContainerName());
     typedef typename itk::InPlaceImageToDream3DDataFilter<PixelType,Dimensions> toDream3DType;
@@ -177,6 +177,12 @@ class ITKImageProcessingImageTest
     if(cDims.size() != 1 || cDims[0] != 1)
     {
       error = QString("Scalar images should have a component dimension of [1]. Found components of size %1 with first value %2").arg(cDims.size()).arg(cDims[0]);
+      DREAM3D_TEST_THROW_EXCEPTION( error.toStdString() );
+    }
+    cDims = ITKDream3DHelper::GetComponentsDimensions<itk::RGBPixel<unsigned char> >();
+    if(cDims.size() != 1 || cDims[0] != 3)
+    {
+      error = QString("RGB images should have a component dimension of [3]. Found components of size %1 with first value %2").arg(cDims.size()).arg(cDims[0]);
       DREAM3D_TEST_THROW_EXCEPTION( error.toStdString() );
     }
     cDims = ITKDream3DHelper::GetComponentsDimensions<itk::RGBAPixel<unsigned char> >();

--- a/Test/ITKTestBase.h
+++ b/Test/ITKTestBase.h
@@ -85,6 +85,13 @@ double ComputeDiff(itk::RGBAPixel<PixelType> p1, itk::RGBAPixel<PixelType> p2)
 }
 
 template<typename PixelType>
+double ComputeDiff(itk::RGBPixel<PixelType> p1, itk::RGBPixel<PixelType> p2)
+{
+    double diff = static_cast<double>((p1-p2).GetScalarValue()) ;
+    return diff;
+}
+
+template<typename PixelType>
 double ComputeDiff(PixelType p1, PixelType p2)
 {
     return static_cast<double>(p1-p2);
@@ -170,6 +177,11 @@ int CompareImages(QVector<size_t> cDims,
       if(cDims[0] == 1)
       {
           return CompareImages<PixelType, Dimensions>(input_container, input_path, baseline_container, baseline_path, tolerance);
+      }
+      // RGB images
+      else if(cDims[0] == 3)
+      {
+          return CompareImages<itk::RGBPixel<PixelType>, Dimensions>(input_container, input_path, baseline_container, baseline_path, tolerance);
       }
       // RGBA images
       else if(cDims[0] == 4)
@@ -444,6 +456,11 @@ int GetMD5FromDataContainer(QVector<size_t> cDims,
       if(cDims[0] == 1)
       {
           return GetMD5FromDataContainer<PixelType, Dimensions>(container, path, md5);
+      }
+      // RGB images
+      else if(cDims[0] == 3)
+      {
+          return GetMD5FromDataContainer<itk::RGBPixel<PixelType>, Dimensions>(container, path, md5);
       }
       // RGBA images
       else if(cDims[0] == 4)


### PR DESCRIPTION
RGB images were loaded as RGBA images when using ITK Image Reader. All ITK
filters were also processing only RGBA images (including ITK Image Writer).
This addresses [1].

[1] https://github.com/BlueQuartzSoftware/ITKImageProcessing/issues/116