### PR TITLE
Create ITKImage library that can be used in other plugins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,6 +284,22 @@ target_link_libraries(${PLUGIN_NAME}
                     )
 
 # --------------------------------------------------------------------
+# Create a library that can be used in other plugins to use ITK/DREAM3D filters
+add_library(ITKImageBase STATIC ITKImageProcessingFilters/ITKImageBase.cpp)
+target_link_libraries(ITKImageBase
+                     SVWidgetsLib
+                     ${ITK_LIBRARIES}
+                     )
+
+target_include_directories(ITKImageBase
+                          PUBLIC
+                          ${PLUGINS_BINARY_DIR}
+                          ${${PLUGIN_NAME}_SOURCE_DIR}
+                          ${PLUGINS_SOURCE_DIR}
+                          )
+
+target_compile_definitions(ITKImageBase PUBLIC STAND_ALONE=1)
+# --------------------------------------------------------------------
 # Put back the output directory
 if(NOT MSVC)
   set(CMAKE_LIBRARY_OUTPUT_DIRECTORY  ${CMAKE_LIBRARY_OUTPUT_DIRECTORY_SAVE}  )

--- a/ITKImageProcessingFilters/ITKImageBase.cpp
+++ b/ITKImageProcessingFilters/ITKImageBase.cpp
@@ -6,9 +6,10 @@
 
 #include "SIMPLib/Geometry/ImageGeom.h"
 
+#ifndef STAND_ALONE
 #include "ITKImageProcessing/ITKImageProcessingConstants.h"
 #include "ITKImageProcessing/ITKImageProcessingVersion.h"
-
+#endif
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
@@ -90,6 +91,7 @@ void ITKImageBase::execute()
   this->filterInternal();
 }
 
+#ifndef STAND_ALONE
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
@@ -124,3 +126,4 @@ const QString ITKImageBase::getGroupName() const
 {
   return "Image Processing";
 }
+#endif

--- a/ITKImageProcessingFilters/ITKImageBase.h
+++ b/ITKImageProcessingFilters/ITKImageBase.h
@@ -47,7 +47,7 @@ public:
 
   SIMPL_FILTER_PARAMETER(bool, SaveAsNewArray)
   Q_PROPERTY(bool SaveAsNewArray READ getSaveAsNewArray WRITE setSaveAsNewArray)
-
+#ifndef STAND_ALONE
   /**
    * @brief getCompiledLibraryName Reimplemented from @see AbstractFilter class
    */
@@ -59,24 +59,21 @@ public:
    * @return Branding string
   */
   virtual const QString getBrandingString() const override;
-
   /**
    * @brief getFilterVersion Returns a version string for this filter. Default
    * value is an empty string.
    * @return
    */
   virtual const QString getFilterVersion() const override;
-
-  /**
-   * @brief newFilterInstance Reimplemented from @see AbstractFilter class
-   */
-  virtual AbstractFilter::Pointer newFilterInstance(bool copyFilterParameters) const override = 0;
-
   /**
    * @brief getGroupName Reimplemented from @see AbstractFilter class
    */
   virtual const QString getGroupName() const override;
-
+#endif
+  /**
+   * @brief newFilterInstance Reimplemented from @see AbstractFilter class
+   */
+  virtual AbstractFilter::Pointer newFilterInstance(bool copyFilterParameters) const override = 0;
   /**
    * @brief getHumanLabel Reimplemented from @see AbstractFilter class
    */


### PR DESCRIPTION
When creating filters that are based on ITK in other plugins, it is convenient
to be able to use what has been implemented in this plugin for this purpose,
and not have to duplicate this code. This patch creates a library that
can be integrated in other plugins for this purpose.