### PR TITLE
Update to work with ITK 5.0.0 and new ImageGeom

### DIFF
--- a/ITKImageProcessingFilters/Dream3DTemplateAliasMacro.h
+++ b/ITKImageProcessingFilters/Dream3DTemplateAliasMacro.h
@@ -450,7 +450,7 @@
       if(imageGeometry.get() != nullptr)                                                                                                                                                               \
       {                                                                                                                                                                                                \
         QVector<size_t> tDims(3, 0);                                                                                                                                                                   \
-        imageGeometry->getDimensions(tDims[0], tDims[1], tDims[2]);                                                                                                                                    \
+        std::tie(tDims[0], tDims[1], tDims[2]) = imageGeometry->getDimensions();                                                                                                                                    \
         if(getErrorCondition() >= 0)                                                                                                                                                                   \
         {                                                                                                                                                                                              \
           QString str_type = ptr->getTypeAsString();                                                                                                                                                   \

--- a/ITKImageProcessingFilters/SourceList.cmake
+++ b/ITKImageProcessingFilters/SourceList.cmake
@@ -51,7 +51,7 @@ if(NOT ITKImageProcessing_LeanAndMean)
     ITKShiftScaleImage
     ITKNotImage
     ITKBinaryProjectionImage
-    ITKBinaryMinMaxCurvatureFlowImage
+#    ITKBinaryMinMaxCurvatureFlowImage
     ITKInvertIntensityImage
     ITKGrayscaleFillholeImage
     ITKAsinImage
@@ -63,7 +63,7 @@ if(NOT ITKImageProcessing_LeanAndMean)
     ITKValuedRegionalMinimaImage
     ITKLog10Image
     ITKSquareImage
-    ITKSobelEdgeDetectionImage
+#    ITKSobelEdgeDetectionImage
     ITKBilateralImage
     ITKValuedRegionalMaximaImage
     ITKRelabelComponentImage

--- a/ITKImageProcessingFilters/itkDream3DImage.h
+++ b/ITKImageProcessingFilters/itkDream3DImage.h
@@ -158,11 +158,11 @@ public:
 
   /** Allocate the image memory. The size of the image must
   * already be set, e.g. by calling SetRegions(). */
-  virtual void Allocate(bool initializePixels = false) ITK_OVERRIDE;
+  virtual void Allocate(bool initializePixels = false) override;
 
   /** Restore the data object to its initial state. This means releasing
   * memory. */
-  virtual void Initialize() ITK_OVERRIDE;
+  virtual void Initialize() override;
 
   /** Fill the image buffer with a value.  Be sure to call Allocate()
   * first. */
@@ -201,11 +201,11 @@ public:
 
   /** Return a pointer to the beginning of the buffer.  This is used by
   * the image iterator class. */
-  virtual TPixel* GetBufferPointer() ITK_OVERRIDE
+  virtual TPixel* GetBufferPointer() override
   {
     return m_TemplatedBuffer ? m_TemplatedBuffer->GetBufferPointer() : ITK_NULLPTR;
   }
-  virtual const TPixel* GetBufferPointer() const ITK_OVERRIDE
+  virtual const TPixel* GetBufferPointer() const override
   {
     return m_TemplatedBuffer ? m_TemplatedBuffer->GetBufferPointer() : ITK_NULLPTR;
   }
@@ -235,7 +235,7 @@ public:
   * simply calls CopyInformation() and copies the region ivars.
   * The implementation here refers to the superclass' implementation
   * and then copies over the pixel container. */
-  virtual void Graft(const DataObject* data) ITK_OVERRIDE;
+  virtual void Graft(const DataObject* data) override;
 
   /** Return the Pixel Accessor object */
   AccessorType GetPixelAccessor(void)
@@ -263,15 +263,15 @@ public:
 
 protected:
   Dream3DImage();
-  void PrintSelf(std::ostream& os, Indent indent) const ITK_OVERRIDE;
+  void PrintSelf(std::ostream& os, Indent indent) const override;
 
   virtual ~Dream3DImage()
   {
   }
 
 private:
-  Dream3DImage(const Self&) ITK_DELETE_FUNCTION;
-  void operator=(const Self&) ITK_DELETE_FUNCTION;
+  Dream3DImage(const Self&) = delete;
+  void operator=(const Self&) = delete;
 
   /** Memory for the current buffer. */
   PixelContainerPointer m_TemplatedBuffer;

--- a/ITKImageProcessingFilters/itkImportDream3DImageContainer.h
+++ b/ITKImageProcessingFilters/itkImportDream3DImageContainer.h
@@ -70,20 +70,20 @@ protected:
   /** PrintSelf routine. Normally this is a protected internal method. It is
   * made public here so that Image can call this method.  Users should not
   * call this method but should call Print() instead. */
-  virtual void PrintSelf(std::ostream& os, Indent indent) const ITK_OVERRIDE;
+  virtual void PrintSelf(std::ostream& os, Indent indent) const override;
 
   /**
   * Allocates elements of the array.  If UseDefaultConstructor is true, then
   * the default constructor is used to initialize each element.  POD date types
   * initialize to zero.
   */
-  virtual Element* AllocateElements(ElementIdentifier size, bool UseDefaultConstructor = false) const ITK_OVERRIDE;
+  virtual Element* AllocateElements(ElementIdentifier size, bool UseDefaultConstructor = false) const override;
 
-  virtual void DeallocateManagedMemory() ITK_OVERRIDE;
+  virtual void DeallocateManagedMemory() override;
 
 private:
-  ImportDream3DImageContainer(const Self&) ITK_DELETE_FUNCTION;
-  void operator=(const Self&) ITK_DELETE_FUNCTION;
+  ImportDream3DImageContainer(const Self&) = delete;
+  void operator=(const Self&) = delete;
 };
 } // end namespace itk
 

--- a/ITKImageProcessingFilters/itkInPlaceDream3DDataToImageFilter.h
+++ b/ITKImageProcessingFilters/itkInPlaceDream3DDataToImageFilter.h
@@ -48,10 +48,10 @@ protected:
   InPlaceDream3DDataToImageFilter();
   virtual ~InPlaceDream3DDataToImageFilter();
 
-  virtual void VerifyPreconditions() ITK_OVERRIDE;
+  virtual void VerifyPreconditions() override;
 
-  virtual void GenerateOutputInformation() ITK_OVERRIDE;
-  virtual void GenerateData() ITK_OVERRIDE;
+  virtual void GenerateOutputInformation() override;
+  virtual void GenerateData() override;
   DataContainer::Pointer m_DataContainer;
 
 private:

--- a/ITKImageProcessingFilters/itkInPlaceImageToDream3DDataFilter.h
+++ b/ITKImageProcessingFilters/itkInPlaceImageToDream3DDataFilter.h
@@ -52,11 +52,11 @@ protected:
   InPlaceImageToDream3DDataFilter();
   virtual ~InPlaceImageToDream3DDataFilter();
 
-  virtual void VerifyPreconditions() ITK_OVERRIDE;
+  virtual void VerifyPreconditions() override;
   ProcessObject::DataObjectPointer MakeOutput(ProcessObject::DataObjectPointerArraySizeType) override;
 
-  virtual void GenerateData() ITK_OVERRIDE;
-  virtual void GenerateOutputInformation() ITK_OVERRIDE;
+  virtual void GenerateData() override;
+  virtual void GenerateOutputInformation() override;
 
   void CheckValidArrayPathComponentName(std::string var);
 

--- a/Test/CMakeLists.txt
+++ b/Test/CMakeLists.txt
@@ -36,7 +36,7 @@ if(NOT ITKImageProcessing_LeanAndMean)
     ITKShiftScaleImageTest
     ITKNotImageTest
     ITKBinaryProjectionImageTest
-    ITKBinaryMinMaxCurvatureFlowImageTest
+#    ITKBinaryMinMaxCurvatureFlowImageTest
     ITKInvertIntensityImageTest
     ITKGrayscaleFillholeImageTest
     ITKAsinImageTest
@@ -48,7 +48,7 @@ if(NOT ITKImageProcessing_LeanAndMean)
     ITKValuedRegionalMinimaImageTest
     ITKLog10ImageTest
     ITKSquareImageTest
-    ITKSobelEdgeDetectionImageTest
+#    ITKSobelEdgeDetectionImageTest
     ITKValuedRegionalMaximaImageTest
     ITKRelabelComponentImageTest
     ITKGrayscaleGrindPeakImageTest


### PR DESCRIPTION
Additionally, 2 ITK filters, ITKBinaryMinMaxCurvatureFlowImage and
ITKSobelEdgeDetectionImage were deactivated as they do not compile
yet with ITK 5.0.0.