### PR TITLE
Fix failing ITKImageProcessing Unit tests

### DIFF
--- a/ITKImageProcessingFilters/ITKImageReader.cpp
+++ b/ITKImageProcessingFilters/ITKImageReader.cpp
@@ -165,7 +165,7 @@ void ITKImageReader::execute()
 AbstractFilter::Pointer ITKImageReader::newFilterInstance(bool copyFilterParameters) const
 {
   ITKImageReader::Pointer filter = ITKImageReader::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKImageWriter.cpp
+++ b/ITKImageProcessingFilters/ITKImageWriter.cpp
@@ -277,6 +277,10 @@ void ITKImageWriter::writeAsOneFile(typename itk::Dream3DImage<TPixel, Dimension
   typedef itk::Dream3DImage<TPixel, Dimensions> ImageType;
   typedef itk::ImageFileWriter<ImageType> FileWriterType;
   typename FileWriterType::Pointer writer = FileWriterType::New();
+
+  QString progress = QString("Saving %1").arg(getFileName());
+  notifyStatusMessage(getHumanLabel(), progress);
+
   writer->SetInput(image);
   writer->SetFileName(getFileName().toStdString().c_str());
   writer->UseCompressionOn();
@@ -428,9 +432,6 @@ void ITKImageWriter::execute()
           copyTuple(index, axisA, dB, axisB, nComp, currentData.get(), sliceData.get());
         }
       }
-      QString progress = QString("%1::Saving Image %2/%3").arg(getHumanLabel()).arg(slice).arg(dims[2]);
-      notifyStatusMessage(getHumanLabel(), progress);
-
       saveImageData(dca, slice, dims[2]);
     }
   }
@@ -448,9 +449,7 @@ void ITKImageWriter::execute()
           size_t index = (dims[1] * axisA * dB) + (slice * dB) + axisB;
           copyTuple(index, axisA, dB, axisB, nComp, currentData.get(), sliceData.get());
         }
-      }
-      QString progress = QString("%1::Saving Image %2/%3").arg(getHumanLabel()).arg(slice).arg(dims[1]);
-      notifyStatusMessage(getHumanLabel(), progress);      
+      } 
       saveImageData(dca, slice, dims[1]);
     }
   }
@@ -469,8 +468,6 @@ void ITKImageWriter::execute()
           copyTuple(index, axisA, dB, axisB, nComp, currentData.get(), sliceData.get());
         }
       }
-      QString progress = QString("%1::Saving Image %2/%3").arg(getHumanLabel()).arg(slice).arg(dims[0]);
-      notifyStatusMessage(getHumanLabel(), progress);      
       saveImageData(dca, slice, dims[0]);
     }
   }

--- a/ITKImageProcessingFilters/ITKImportImageStack.cpp
+++ b/ITKImageProcessingFilters/ITKImportImageStack.cpp
@@ -233,15 +233,38 @@ void ITKImportImageStack::readImage(const QVector<QString>& fileList, bool dataC
     imageIO->SetFileName(filename.toLatin1());
     imageIO->ReadImageInformation();
 
-    typedef itk::ImageIOBase::IOComponentType ComponentType;
+    using ComponentType = itk::ImageIOBase::IOComponentType;
     const ComponentType type = imageIO->GetComponentType();
     const unsigned int dimensions = imageIO->GetNumberOfDimensions();
-    if(dimensions != 2)
+    if(dimensions == 3)
     {
-      setErrorCondition(-1);
-      const QString errorMessage = QString("Slice image dimensions do not equal 2. Dimension of current image is %1").arg(dimensions);
-      notifyErrorMessage(getHumanLabel(), errorMessage, getErrorCondition());
-      return;
+      //      itk::ImageIOBase::SizeValueType dim0 = imageIO->GetDimensions(0);
+      //      itk::ImageIOBase::SizeValueType dim1 = imageIO->GetDimensions(1);
+      itk::ImageIOBase::SizeValueType dim2 = imageIO->GetDimensions(2);
+      // std::cout << "ITKImportImageStack: Input Image Dims: " << dim0 << ", " << dim1 << ", " << dim2 << std::endl;
+
+      if(dim2 != 1)
+      {
+        setErrorCondition(-2342342);
+        const QString errorMessage = QString("The Z Dimension of the image file does not equal 1. Dimension of Z is %1").arg(dim2);
+        notifyErrorMessage(getHumanLabel(), errorMessage, getErrorCondition());
+        return;
+      }
+    }
+    else if(dimensions > 3)
+    {
+      QString msg;
+      QTextStream out(&msg);
+      out << "Slice image dimensions do not equal 2. The dimenions of the image are:";
+      for(unsigned int i = 0; i < dimensions; i++)
+      {
+        itk::ImageIOBase::SizeValueType dim = imageIO->GetDimensions(i);
+        out << dim;
+        if(i != dimensions - 1)
+        {
+          out << ", ";
+        }
+      }
     }
 
     switch(type)

--- a/Test/CMakeLists.txt
+++ b/Test/CMakeLists.txt
@@ -135,4 +135,8 @@ SIMPL_GenerateUnitTestFile(PLUGIN_NAME ${PLUGIN_NAME}
                                         ${${PLUGIN_NAME}_PARENT_BINARY_DIR}
 )
 
+if(${${PLUGIN_NAME}_ENABLE_SCIFIO})
+  target_compile_definitions(${PLUGIN_NAME}UnitTest PUBLIC "ITK_IMAGE_PROCESSING_HAVE_SCIFIO")
+endif()
+
 add_dependencies(${PLUGIN_NAME}UnitTest ${PLUGIN_NAME}Gui)


### PR DESCRIPTION
ITKImageProcessingWriterTest has been updated with the following fixes:
+ All temp files are removed after tests are completed
+ 2D Images that say they are 3D with a z dimension of 1 are now read by the
ITKImageImageStack filter.
+ Most formats are now being tested except those where SCIFIO is needed. Those are
tested if SCIFIO support is enabled in SIMPLib
+ ITKImageWriter has more precise progress messages about what exact files are being written

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>