### PR TITLE
Update all classes to properly implement constructors and assignment operators

### DIFF
--- a/ITKImageProcessingFilters/ITKAbsImage.h
+++ b/ITKImageProcessingFilters/ITKAbsImage.h
@@ -90,7 +90,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKAbsImage(const ITKAbsImage&) = delete;    // Copy Constructor Not Implemented
   ITKAbsImage(ITKAbsImage&&) = delete;         // Move Constructor Not Implemented
   ITKAbsImage& operator=(const ITKAbsImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKAcosImage.h
+++ b/ITKImageProcessingFilters/ITKAcosImage.h
@@ -90,7 +90,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKAcosImage(const ITKAcosImage&) = delete;    // Copy Constructor Not Implemented
   ITKAcosImage(ITKAcosImage&&) = delete;         // Move Constructor Not Implemented
   ITKAcosImage& operator=(const ITKAcosImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKAdaptiveHistogramEqualizationImage.h
+++ b/ITKImageProcessingFilters/ITKAdaptiveHistogramEqualizationImage.h
@@ -105,7 +105,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKAdaptiveHistogramEqualizationImage(const ITKAdaptiveHistogramEqualizationImage&) = delete;    // Copy Constructor Not Implemented
   ITKAdaptiveHistogramEqualizationImage(ITKAdaptiveHistogramEqualizationImage&&) = delete;         // Move Constructor Not Implemented
   ITKAdaptiveHistogramEqualizationImage& operator=(const ITKAdaptiveHistogramEqualizationImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKApproximateSignedDistanceMapImage.h
+++ b/ITKImageProcessingFilters/ITKApproximateSignedDistanceMapImage.h
@@ -100,7 +100,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKApproximateSignedDistanceMapImage(const ITKApproximateSignedDistanceMapImage&) = delete;    // Copy Constructor Not Implemented
   ITKApproximateSignedDistanceMapImage(ITKApproximateSignedDistanceMapImage&&) = delete;         // Move Constructor Not Implemented
   ITKApproximateSignedDistanceMapImage& operator=(const ITKApproximateSignedDistanceMapImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKAsinImage.h
+++ b/ITKImageProcessingFilters/ITKAsinImage.h
@@ -89,7 +89,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKAsinImage(const ITKAsinImage&) = delete;    // Copy Constructor Not Implemented
   ITKAsinImage(ITKAsinImage&&) = delete;         // Move Constructor Not Implemented
   ITKAsinImage& operator=(const ITKAsinImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKAtanImage.h
+++ b/ITKImageProcessingFilters/ITKAtanImage.h
@@ -90,7 +90,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKAtanImage(const ITKAtanImage&) = delete;    // Copy Constructor Not Implemented
   ITKAtanImage(ITKAtanImage&&) = delete;         // Move Constructor Not Implemented
   ITKAtanImage& operator=(const ITKAtanImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKBilateralImage.h
+++ b/ITKImageProcessingFilters/ITKBilateralImage.h
@@ -104,7 +104,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKBilateralImage(const ITKBilateralImage&) = delete;    // Copy Constructor Not Implemented
   ITKBilateralImage(ITKBilateralImage&&) = delete;         // Move Constructor Not Implemented
   ITKBilateralImage& operator=(const ITKBilateralImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKBinaryClosingByReconstructionImage.h
+++ b/ITKImageProcessingFilters/ITKBinaryClosingByReconstructionImage.h
@@ -111,7 +111,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKBinaryClosingByReconstructionImage(const ITKBinaryClosingByReconstructionImage&) = delete;    // Copy Constructor Not Implemented
   ITKBinaryClosingByReconstructionImage(ITKBinaryClosingByReconstructionImage&&) = delete;         // Move Constructor Not Implemented
   ITKBinaryClosingByReconstructionImage& operator=(const ITKBinaryClosingByReconstructionImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKBinaryContourImage.h
+++ b/ITKImageProcessingFilters/ITKBinaryContourImage.h
@@ -105,7 +105,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKBinaryContourImage(const ITKBinaryContourImage&) = delete;    // Copy Constructor Not Implemented
   ITKBinaryContourImage(ITKBinaryContourImage&&) = delete;         // Move Constructor Not Implemented
   ITKBinaryContourImage& operator=(const ITKBinaryContourImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKBinaryDilateImage.h
+++ b/ITKImageProcessingFilters/ITKBinaryDilateImage.h
@@ -115,7 +115,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKBinaryDilateImage(const ITKBinaryDilateImage&) = delete;    // Copy Constructor Not Implemented
   ITKBinaryDilateImage(ITKBinaryDilateImage&&) = delete;         // Move Constructor Not Implemented
   ITKBinaryDilateImage& operator=(const ITKBinaryDilateImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKBinaryErodeImage.h
+++ b/ITKImageProcessingFilters/ITKBinaryErodeImage.h
@@ -115,7 +115,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKBinaryErodeImage(const ITKBinaryErodeImage&) = delete;    // Copy Constructor Not Implemented
   ITKBinaryErodeImage(ITKBinaryErodeImage&&) = delete;         // Move Constructor Not Implemented
   ITKBinaryErodeImage& operator=(const ITKBinaryErodeImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKBinaryMinMaxCurvatureFlowImage.h
+++ b/ITKImageProcessingFilters/ITKBinaryMinMaxCurvatureFlowImage.h
@@ -109,7 +109,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKBinaryMinMaxCurvatureFlowImage(const ITKBinaryMinMaxCurvatureFlowImage&) = delete;    // Copy Constructor Not Implemented
   ITKBinaryMinMaxCurvatureFlowImage(ITKBinaryMinMaxCurvatureFlowImage&&) = delete;         // Move Constructor Not Implemented
   ITKBinaryMinMaxCurvatureFlowImage& operator=(const ITKBinaryMinMaxCurvatureFlowImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKBinaryMorphologicalClosingImage.h
+++ b/ITKImageProcessingFilters/ITKBinaryMorphologicalClosingImage.h
@@ -111,7 +111,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKBinaryMorphologicalClosingImage(const ITKBinaryMorphologicalClosingImage&) = delete;    // Copy Constructor Not Implemented
   ITKBinaryMorphologicalClosingImage(ITKBinaryMorphologicalClosingImage&&) = delete;         // Move Constructor Not Implemented
   ITKBinaryMorphologicalClosingImage& operator=(const ITKBinaryMorphologicalClosingImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKBinaryMorphologicalOpeningImage.h
+++ b/ITKImageProcessingFilters/ITKBinaryMorphologicalOpeningImage.h
@@ -110,7 +110,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKBinaryMorphologicalOpeningImage(const ITKBinaryMorphologicalOpeningImage&) = delete;    // Copy Constructor Not Implemented
   ITKBinaryMorphologicalOpeningImage(ITKBinaryMorphologicalOpeningImage&&) = delete;         // Move Constructor Not Implemented
   ITKBinaryMorphologicalOpeningImage& operator=(const ITKBinaryMorphologicalOpeningImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKBinaryOpeningByReconstructionImage.h
+++ b/ITKImageProcessingFilters/ITKBinaryOpeningByReconstructionImage.h
@@ -115,7 +115,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKBinaryOpeningByReconstructionImage(const ITKBinaryOpeningByReconstructionImage&) = delete;    // Copy Constructor Not Implemented
   ITKBinaryOpeningByReconstructionImage(ITKBinaryOpeningByReconstructionImage&&) = delete;         // Move Constructor Not Implemented
   ITKBinaryOpeningByReconstructionImage& operator=(const ITKBinaryOpeningByReconstructionImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKBinaryProjectionImage.h
+++ b/ITKImageProcessingFilters/ITKBinaryProjectionImage.h
@@ -104,7 +104,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKBinaryProjectionImage(const ITKBinaryProjectionImage&) = delete;    // Copy Constructor Not Implemented
   ITKBinaryProjectionImage(ITKBinaryProjectionImage&&) = delete;         // Move Constructor Not Implemented
   ITKBinaryProjectionImage& operator=(const ITKBinaryProjectionImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKBinaryThinningImage.h
+++ b/ITKImageProcessingFilters/ITKBinaryThinningImage.h
@@ -89,7 +89,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKBinaryThinningImage(const ITKBinaryThinningImage&) = delete;    // Copy Constructor Not Implemented
   ITKBinaryThinningImage(ITKBinaryThinningImage&&) = delete;         // Move Constructor Not Implemented
   ITKBinaryThinningImage& operator=(const ITKBinaryThinningImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKBinaryThresholdImage.h
+++ b/ITKImageProcessingFilters/ITKBinaryThresholdImage.h
@@ -109,7 +109,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKBinaryThresholdImage(const ITKBinaryThresholdImage&) = delete;    // Copy Constructor Not Implemented
   ITKBinaryThresholdImage(ITKBinaryThresholdImage&&) = delete;         // Move Constructor Not Implemented
   ITKBinaryThresholdImage& operator=(const ITKBinaryThresholdImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKBinomialBlurImage.h
+++ b/ITKImageProcessingFilters/ITKBinomialBlurImage.h
@@ -96,7 +96,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKBinomialBlurImage(const ITKBinomialBlurImage&) = delete;    // Copy Constructor Not Implemented
   ITKBinomialBlurImage(ITKBinomialBlurImage&&) = delete;         // Move Constructor Not Implemented
   ITKBinomialBlurImage& operator=(const ITKBinomialBlurImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKBlackTopHatImage.h
+++ b/ITKImageProcessingFilters/ITKBlackTopHatImage.h
@@ -106,7 +106,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKBlackTopHatImage(const ITKBlackTopHatImage&) = delete;    // Copy Constructor Not Implemented
   ITKBlackTopHatImage(ITKBlackTopHatImage&&) = delete;         // Move Constructor Not Implemented
   ITKBlackTopHatImage& operator=(const ITKBlackTopHatImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKBoundedReciprocalImage.h
+++ b/ITKImageProcessingFilters/ITKBoundedReciprocalImage.h
@@ -89,7 +89,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKBoundedReciprocalImage(const ITKBoundedReciprocalImage&) = delete;    // Copy Constructor Not Implemented
   ITKBoundedReciprocalImage(ITKBoundedReciprocalImage&&) = delete;         // Move Constructor Not Implemented
   ITKBoundedReciprocalImage& operator=(const ITKBoundedReciprocalImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKBoxMeanImage.h
+++ b/ITKImageProcessingFilters/ITKBoxMeanImage.h
@@ -96,7 +96,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKBoxMeanImage(const ITKBoxMeanImage&) = delete;    // Copy Constructor Not Implemented
   ITKBoxMeanImage(ITKBoxMeanImage&&) = delete;         // Move Constructor Not Implemented
   ITKBoxMeanImage& operator=(const ITKBoxMeanImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKCastImage.h
+++ b/ITKImageProcessingFilters/ITKCastImage.h
@@ -92,8 +92,9 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
-  ITKCastImage(const ITKCastImage&);   // Copy Constructor Not Implemented
+public:
+  ITKCastImage(const ITKCastImage&) = delete;            // Copy Constructor Not Implemented
+  ITKCastImage(ITKCastImage&&) = delete;                 // Move Constructor Not Implemented
   ITKCastImage& operator=(const ITKCastImage&) = delete; // Copy Assignment Not Implemented
   ITKCastImage& operator=(ITKCastImage&&) = delete;      // Move Assignment Not Implemented
 };

--- a/ITKImageProcessingFilters/ITKClosingByReconstructionImage.h
+++ b/ITKImageProcessingFilters/ITKClosingByReconstructionImage.h
@@ -110,7 +110,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKClosingByReconstructionImage(const ITKClosingByReconstructionImage&) = delete;    // Copy Constructor Not Implemented
   ITKClosingByReconstructionImage(ITKClosingByReconstructionImage&&) = delete;         // Move Constructor Not Implemented
   ITKClosingByReconstructionImage& operator=(const ITKClosingByReconstructionImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKConnectedComponentImage.h
+++ b/ITKImageProcessingFilters/ITKConnectedComponentImage.h
@@ -101,7 +101,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKConnectedComponentImage(const ITKConnectedComponentImage&) = delete;    // Copy Constructor Not Implemented
   ITKConnectedComponentImage(ITKConnectedComponentImage&&) = delete;         // Move Constructor Not Implemented
   ITKConnectedComponentImage& operator=(const ITKConnectedComponentImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKCosImage.h
+++ b/ITKImageProcessingFilters/ITKCosImage.h
@@ -89,7 +89,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKCosImage(const ITKCosImage&) = delete;    // Copy Constructor Not Implemented
   ITKCosImage(ITKCosImage&&) = delete;         // Move Constructor Not Implemented
   ITKCosImage& operator=(const ITKCosImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKCurvatureAnisotropicDiffusionImage.h
+++ b/ITKImageProcessingFilters/ITKCurvatureAnisotropicDiffusionImage.h
@@ -109,7 +109,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKCurvatureAnisotropicDiffusionImage(const ITKCurvatureAnisotropicDiffusionImage&) = delete;    // Copy Constructor Not Implemented
   ITKCurvatureAnisotropicDiffusionImage(ITKCurvatureAnisotropicDiffusionImage&&) = delete;         // Move Constructor Not Implemented
   ITKCurvatureAnisotropicDiffusionImage& operator=(const ITKCurvatureAnisotropicDiffusionImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKCurvatureFlowImage.h
+++ b/ITKImageProcessingFilters/ITKCurvatureFlowImage.h
@@ -100,7 +100,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKCurvatureFlowImage(const ITKCurvatureFlowImage&) = delete;    // Copy Constructor Not Implemented
   ITKCurvatureFlowImage(ITKCurvatureFlowImage&&) = delete;         // Move Constructor Not Implemented
   ITKCurvatureFlowImage& operator=(const ITKCurvatureFlowImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKDanielssonDistanceMapImage.h
+++ b/ITKImageProcessingFilters/ITKDanielssonDistanceMapImage.h
@@ -104,7 +104,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKDanielssonDistanceMapImage(const ITKDanielssonDistanceMapImage&) = delete;    // Copy Constructor Not Implemented
   ITKDanielssonDistanceMapImage(ITKDanielssonDistanceMapImage&&) = delete;         // Move Constructor Not Implemented
   ITKDanielssonDistanceMapImage& operator=(const ITKDanielssonDistanceMapImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKDilateObjectMorphologyImage.h
+++ b/ITKImageProcessingFilters/ITKDilateObjectMorphologyImage.h
@@ -106,7 +106,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKDilateObjectMorphologyImage(const ITKDilateObjectMorphologyImage&) = delete;    // Copy Constructor Not Implemented
   ITKDilateObjectMorphologyImage(ITKDilateObjectMorphologyImage&&) = delete;         // Move Constructor Not Implemented
   ITKDilateObjectMorphologyImage& operator=(const ITKDilateObjectMorphologyImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKDiscreteGaussianImage.h
+++ b/ITKImageProcessingFilters/ITKDiscreteGaussianImage.h
@@ -110,7 +110,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKDiscreteGaussianImage(const ITKDiscreteGaussianImage&) = delete;    // Copy Constructor Not Implemented
   ITKDiscreteGaussianImage(ITKDiscreteGaussianImage&&) = delete;         // Move Constructor Not Implemented
   ITKDiscreteGaussianImage& operator=(const ITKDiscreteGaussianImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKDoubleThresholdImage.h
+++ b/ITKImageProcessingFilters/ITKDoubleThresholdImage.h
@@ -122,7 +122,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKDoubleThresholdImage(const ITKDoubleThresholdImage&) = delete;    // Copy Constructor Not Implemented
   ITKDoubleThresholdImage(ITKDoubleThresholdImage&&) = delete;         // Move Constructor Not Implemented
   ITKDoubleThresholdImage& operator=(const ITKDoubleThresholdImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKErodeObjectMorphologyImage.h
+++ b/ITKImageProcessingFilters/ITKErodeObjectMorphologyImage.h
@@ -110,7 +110,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKErodeObjectMorphologyImage(const ITKErodeObjectMorphologyImage&) = delete;    // Copy Constructor Not Implemented
   ITKErodeObjectMorphologyImage(ITKErodeObjectMorphologyImage&&) = delete;         // Move Constructor Not Implemented
   ITKErodeObjectMorphologyImage& operator=(const ITKErodeObjectMorphologyImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKExpImage.h
+++ b/ITKImageProcessingFilters/ITKExpImage.h
@@ -89,7 +89,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKExpImage(const ITKExpImage&) = delete;    // Copy Constructor Not Implemented
   ITKExpImage(ITKExpImage&&) = delete;         // Move Constructor Not Implemented
   ITKExpImage& operator=(const ITKExpImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKExpNegativeImage.h
+++ b/ITKImageProcessingFilters/ITKExpNegativeImage.h
@@ -89,7 +89,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKExpNegativeImage(const ITKExpNegativeImage&) = delete;    // Copy Constructor Not Implemented
   ITKExpNegativeImage(ITKExpNegativeImage&&) = delete;         // Move Constructor Not Implemented
   ITKExpNegativeImage& operator=(const ITKExpNegativeImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKFFTNormalizedCorrelationImage.h
+++ b/ITKImageProcessingFilters/ITKFFTNormalizedCorrelationImage.h
@@ -104,7 +104,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKFFTNormalizedCorrelationImage(const ITKFFTNormalizedCorrelationImage&) = delete; // Copy Constructor Not Implemented
   ITKFFTNormalizedCorrelationImage(ITKFFTNormalizedCorrelationImage&&) = delete;      // Move Constructor Not Implemented
   ITKFFTNormalizedCorrelationImage& operator=(const ITKFFTNormalizedCorrelationImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKGradientAnisotropicDiffusionImage.h
+++ b/ITKImageProcessingFilters/ITKGradientAnisotropicDiffusionImage.h
@@ -109,7 +109,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKGradientAnisotropicDiffusionImage(const ITKGradientAnisotropicDiffusionImage&) = delete;    // Copy Constructor Not Implemented
   ITKGradientAnisotropicDiffusionImage(ITKGradientAnisotropicDiffusionImage&&) = delete;         // Move Constructor Not Implemented
   ITKGradientAnisotropicDiffusionImage& operator=(const ITKGradientAnisotropicDiffusionImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKGradientMagnitudeImage.h
+++ b/ITKImageProcessingFilters/ITKGradientMagnitudeImage.h
@@ -96,7 +96,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKGradientMagnitudeImage(const ITKGradientMagnitudeImage&) = delete;    // Copy Constructor Not Implemented
   ITKGradientMagnitudeImage(ITKGradientMagnitudeImage&&) = delete;         // Move Constructor Not Implemented
   ITKGradientMagnitudeImage& operator=(const ITKGradientMagnitudeImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKGradientMagnitudeRecursiveGaussianImage.h
+++ b/ITKImageProcessingFilters/ITKGradientMagnitudeRecursiveGaussianImage.h
@@ -101,7 +101,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKGradientMagnitudeRecursiveGaussianImage(const ITKGradientMagnitudeRecursiveGaussianImage&) = delete;    // Copy Constructor Not Implemented
   ITKGradientMagnitudeRecursiveGaussianImage(ITKGradientMagnitudeRecursiveGaussianImage&&) = delete;         // Move Constructor Not Implemented
   ITKGradientMagnitudeRecursiveGaussianImage& operator=(const ITKGradientMagnitudeRecursiveGaussianImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKGrayscaleDilateImage.h
+++ b/ITKImageProcessingFilters/ITKGrayscaleDilateImage.h
@@ -101,7 +101,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKGrayscaleDilateImage(const ITKGrayscaleDilateImage&) = delete;    // Copy Constructor Not Implemented
   ITKGrayscaleDilateImage(ITKGrayscaleDilateImage&&) = delete;         // Move Constructor Not Implemented
   ITKGrayscaleDilateImage& operator=(const ITKGrayscaleDilateImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKGrayscaleErodeImage.h
+++ b/ITKImageProcessingFilters/ITKGrayscaleErodeImage.h
@@ -101,7 +101,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKGrayscaleErodeImage(const ITKGrayscaleErodeImage&) = delete;    // Copy Constructor Not Implemented
   ITKGrayscaleErodeImage(ITKGrayscaleErodeImage&&) = delete;         // Move Constructor Not Implemented
   ITKGrayscaleErodeImage& operator=(const ITKGrayscaleErodeImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKGrayscaleFillholeImage.h
+++ b/ITKImageProcessingFilters/ITKGrayscaleFillholeImage.h
@@ -96,7 +96,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKGrayscaleFillholeImage(const ITKGrayscaleFillholeImage&) = delete;    // Copy Constructor Not Implemented
   ITKGrayscaleFillholeImage(ITKGrayscaleFillholeImage&&) = delete;         // Move Constructor Not Implemented
   ITKGrayscaleFillholeImage& operator=(const ITKGrayscaleFillholeImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKGrayscaleGrindPeakImage.h
+++ b/ITKImageProcessingFilters/ITKGrayscaleGrindPeakImage.h
@@ -96,7 +96,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKGrayscaleGrindPeakImage(const ITKGrayscaleGrindPeakImage&) = delete;    // Copy Constructor Not Implemented
   ITKGrayscaleGrindPeakImage(ITKGrayscaleGrindPeakImage&&) = delete;         // Move Constructor Not Implemented
   ITKGrayscaleGrindPeakImage& operator=(const ITKGrayscaleGrindPeakImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKGrayscaleMorphologicalClosingImage.h
+++ b/ITKImageProcessingFilters/ITKGrayscaleMorphologicalClosingImage.h
@@ -106,7 +106,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKGrayscaleMorphologicalClosingImage(const ITKGrayscaleMorphologicalClosingImage&) = delete;    // Copy Constructor Not Implemented
   ITKGrayscaleMorphologicalClosingImage(ITKGrayscaleMorphologicalClosingImage&&) = delete;         // Move Constructor Not Implemented
   ITKGrayscaleMorphologicalClosingImage& operator=(const ITKGrayscaleMorphologicalClosingImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKGrayscaleMorphologicalOpeningImage.h
+++ b/ITKImageProcessingFilters/ITKGrayscaleMorphologicalOpeningImage.h
@@ -106,7 +106,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKGrayscaleMorphologicalOpeningImage(const ITKGrayscaleMorphologicalOpeningImage&) = delete;    // Copy Constructor Not Implemented
   ITKGrayscaleMorphologicalOpeningImage(ITKGrayscaleMorphologicalOpeningImage&&) = delete;         // Move Constructor Not Implemented
   ITKGrayscaleMorphologicalOpeningImage& operator=(const ITKGrayscaleMorphologicalOpeningImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKHMaximaImage.h
+++ b/ITKImageProcessingFilters/ITKHMaximaImage.h
@@ -96,7 +96,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKHMaximaImage(const ITKHMaximaImage&) = delete;    // Copy Constructor Not Implemented
   ITKHMaximaImage(ITKHMaximaImage&&) = delete;         // Move Constructor Not Implemented
   ITKHMaximaImage& operator=(const ITKHMaximaImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKHMinimaImage.h
+++ b/ITKImageProcessingFilters/ITKHMinimaImage.h
@@ -101,7 +101,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKHMinimaImage(const ITKHMinimaImage&) = delete;    // Copy Constructor Not Implemented
   ITKHMinimaImage(ITKHMinimaImage&&) = delete;         // Move Constructor Not Implemented
   ITKHMinimaImage& operator=(const ITKHMinimaImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKHistogramMatchingImage.h
+++ b/ITKImageProcessingFilters/ITKHistogramMatchingImage.h
@@ -127,7 +127,7 @@ protected:
    */
   void CompareImagePixelTypes(const DataArrayPath& path1, const DataArrayPath& path2);
 
-private:
+public:
   ITKHistogramMatchingImage(const ITKHistogramMatchingImage&) = delete; // Copy Constructor Not Implemented
   ITKHistogramMatchingImage(ITKHistogramMatchingImage&&) = delete;      // Move Constructor Not Implemented
   ITKHistogramMatchingImage& operator=(const ITKHistogramMatchingImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKImageBase.h
+++ b/ITKImageProcessingFilters/ITKImageBase.h
@@ -360,6 +360,7 @@ protected:
 
 public:
   ITKImageBase(const ITKImageBase&) = delete;            // Copy Constructor Implemented
+  ITKImageBase(ITKImageBase&&) = delete;                 // Move Constructor Not Implemented
   ITKImageBase& operator=(const ITKImageBase&) = delete; // Copy Assignment Not Implemented
   ITKImageBase& operator=(ITKImageBase&&) = delete;      // Move Assignment Not Implemented
 };

--- a/ITKImageProcessingFilters/ITKIntensityWindowingImage.h
+++ b/ITKImageProcessingFilters/ITKIntensityWindowingImage.h
@@ -108,7 +108,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKIntensityWindowingImage(const ITKIntensityWindowingImage&) = delete;    // Copy Constructor Not Implemented
   ITKIntensityWindowingImage(ITKIntensityWindowingImage&&) = delete;         // Move Constructor Not Implemented
   ITKIntensityWindowingImage& operator=(const ITKIntensityWindowingImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKInvertIntensityImage.h
+++ b/ITKImageProcessingFilters/ITKInvertIntensityImage.h
@@ -96,7 +96,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKInvertIntensityImage(const ITKInvertIntensityImage&) = delete;    // Copy Constructor Not Implemented
   ITKInvertIntensityImage(ITKInvertIntensityImage&&) = delete;         // Move Constructor Not Implemented
   ITKInvertIntensityImage& operator=(const ITKInvertIntensityImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKIsoContourDistanceImage.h
+++ b/ITKImageProcessingFilters/ITKIsoContourDistanceImage.h
@@ -100,7 +100,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKIsoContourDistanceImage(const ITKIsoContourDistanceImage&) = delete;    // Copy Constructor Not Implemented
   ITKIsoContourDistanceImage(ITKIsoContourDistanceImage&&) = delete;         // Move Constructor Not Implemented
   ITKIsoContourDistanceImage& operator=(const ITKIsoContourDistanceImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKLabelContourImage.h
+++ b/ITKImageProcessingFilters/ITKLabelContourImage.h
@@ -101,7 +101,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKLabelContourImage(const ITKLabelContourImage&) = delete;    // Copy Constructor Not Implemented
   ITKLabelContourImage(ITKLabelContourImage&&) = delete;         // Move Constructor Not Implemented
   ITKLabelContourImage& operator=(const ITKLabelContourImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKLaplacianRecursiveGaussianImage.h
+++ b/ITKImageProcessingFilters/ITKLaplacianRecursiveGaussianImage.h
@@ -101,7 +101,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKLaplacianRecursiveGaussianImage(const ITKLaplacianRecursiveGaussianImage&) = delete;    // Copy Constructor Not Implemented
   ITKLaplacianRecursiveGaussianImage(ITKLaplacianRecursiveGaussianImage&&) = delete;         // Move Constructor Not Implemented
   ITKLaplacianRecursiveGaussianImage& operator=(const ITKLaplacianRecursiveGaussianImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKLaplacianSharpeningImage.h
+++ b/ITKImageProcessingFilters/ITKLaplacianSharpeningImage.h
@@ -96,7 +96,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKLaplacianSharpeningImage(const ITKLaplacianSharpeningImage&) = delete;    // Copy Constructor Not Implemented
   ITKLaplacianSharpeningImage(ITKLaplacianSharpeningImage&&) = delete;         // Move Constructor Not Implemented
   ITKLaplacianSharpeningImage& operator=(const ITKLaplacianSharpeningImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKLog10Image.h
+++ b/ITKImageProcessingFilters/ITKLog10Image.h
@@ -89,7 +89,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKLog10Image(const ITKLog10Image&) = delete;    // Copy Constructor Not Implemented
   ITKLog10Image(ITKLog10Image&&) = delete;         // Move Constructor Not Implemented
   ITKLog10Image& operator=(const ITKLog10Image&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKLogImage.h
+++ b/ITKImageProcessingFilters/ITKLogImage.h
@@ -89,7 +89,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKLogImage(const ITKLogImage&) = delete;    // Copy Constructor Not Implemented
   ITKLogImage(ITKLogImage&&) = delete;         // Move Constructor Not Implemented
   ITKLogImage& operator=(const ITKLogImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKMaskImage.h
+++ b/ITKImageProcessingFilters/ITKMaskImage.h
@@ -109,8 +109,9 @@ protected:
 
   template <typename InputPixelType, typename OutputPixelType, unsigned int Dimension> typename std::enable_if<!std::is_scalar<InputPixelType>::value>::type convertDataContainerType();
 
-private:
-  ITKMaskImage(const ITKMaskImage&);   // Copy Constructor Not Implemented
+public:
+  ITKMaskImage(const ITKMaskImage&) = delete;            // Copy Constructor Not Implemented
+  ITKMaskImage(ITKMaskImage&&) = delete;                 // Move Constructor Not Implemented
   ITKMaskImage& operator=(const ITKMaskImage&) = delete; // Copy Assignment Not Implemented
   ITKMaskImage& operator=(ITKMaskImage&&) = delete;      // Move Assignment Not Implemented
 };

--- a/ITKImageProcessingFilters/ITKMaximumProjectionImage.h
+++ b/ITKImageProcessingFilters/ITKMaximumProjectionImage.h
@@ -96,7 +96,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKMaximumProjectionImage(const ITKMaximumProjectionImage&) = delete;    // Copy Constructor Not Implemented
   ITKMaximumProjectionImage(ITKMaximumProjectionImage&&) = delete;         // Move Constructor Not Implemented
   ITKMaximumProjectionImage& operator=(const ITKMaximumProjectionImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKMeanProjectionImage.h
+++ b/ITKImageProcessingFilters/ITKMeanProjectionImage.h
@@ -96,7 +96,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKMeanProjectionImage(const ITKMeanProjectionImage&) = delete;    // Copy Constructor Not Implemented
   ITKMeanProjectionImage(ITKMeanProjectionImage&&) = delete;         // Move Constructor Not Implemented
   ITKMeanProjectionImage& operator=(const ITKMeanProjectionImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKMedianImage.h
+++ b/ITKImageProcessingFilters/ITKMedianImage.h
@@ -96,7 +96,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKMedianImage(const ITKMedianImage&) = delete;    // Copy Constructor Not Implemented
   ITKMedianImage(ITKMedianImage&&) = delete;         // Move Constructor Not Implemented
   ITKMedianImage& operator=(const ITKMedianImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKMedianProjectionImage.h
+++ b/ITKImageProcessingFilters/ITKMedianProjectionImage.h
@@ -96,7 +96,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKMedianProjectionImage(const ITKMedianProjectionImage&) = delete;    // Copy Constructor Not Implemented
   ITKMedianProjectionImage(ITKMedianProjectionImage&&) = delete;         // Move Constructor Not Implemented
   ITKMedianProjectionImage& operator=(const ITKMedianProjectionImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKMinMaxCurvatureFlowImage.h
+++ b/ITKImageProcessingFilters/ITKMinMaxCurvatureFlowImage.h
@@ -105,7 +105,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKMinMaxCurvatureFlowImage(const ITKMinMaxCurvatureFlowImage&) = delete;    // Copy Constructor Not Implemented
   ITKMinMaxCurvatureFlowImage(ITKMinMaxCurvatureFlowImage&&) = delete;         // Move Constructor Not Implemented
   ITKMinMaxCurvatureFlowImage& operator=(const ITKMinMaxCurvatureFlowImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKMinimumProjectionImage.h
+++ b/ITKImageProcessingFilters/ITKMinimumProjectionImage.h
@@ -96,7 +96,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKMinimumProjectionImage(const ITKMinimumProjectionImage&) = delete;    // Copy Constructor Not Implemented
   ITKMinimumProjectionImage(ITKMinimumProjectionImage&&) = delete;         // Move Constructor Not Implemented
   ITKMinimumProjectionImage& operator=(const ITKMinimumProjectionImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKMorphologicalGradientImage.h
+++ b/ITKImageProcessingFilters/ITKMorphologicalGradientImage.h
@@ -101,7 +101,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKMorphologicalGradientImage(const ITKMorphologicalGradientImage&) = delete;    // Copy Constructor Not Implemented
   ITKMorphologicalGradientImage(ITKMorphologicalGradientImage&&) = delete;         // Move Constructor Not Implemented
   ITKMorphologicalGradientImage& operator=(const ITKMorphologicalGradientImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKMorphologicalWatershedFromMarkersImage.h
+++ b/ITKImageProcessingFilters/ITKMorphologicalWatershedFromMarkersImage.h
@@ -114,7 +114,7 @@ protected:
   */
   template <typename InputPixelType, typename OutputPixelType, unsigned int Dimension> void convertDataContainerType();
 
-private:
+public:
   ITKMorphologicalWatershedFromMarkersImage(const ITKMorphologicalWatershedFromMarkersImage&) = delete; // Copy Constructor Not Implemented
   ITKMorphologicalWatershedFromMarkersImage(ITKMorphologicalWatershedFromMarkersImage&&) = delete;      // Move Constructor Not Implemented
   ITKMorphologicalWatershedFromMarkersImage& operator=(const ITKMorphologicalWatershedFromMarkersImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKMorphologicalWatershedImage.h
+++ b/ITKImageProcessingFilters/ITKMorphologicalWatershedImage.h
@@ -105,7 +105,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKMorphologicalWatershedImage(const ITKMorphologicalWatershedImage&) = delete;    // Copy Constructor Not Implemented
   ITKMorphologicalWatershedImage(ITKMorphologicalWatershedImage&&) = delete;         // Move Constructor Not Implemented
   ITKMorphologicalWatershedImage& operator=(const ITKMorphologicalWatershedImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKMultiScaleHessianBasedObjectnessImage.h
+++ b/ITKImageProcessingFilters/ITKMultiScaleHessianBasedObjectnessImage.h
@@ -126,7 +126,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKMultiScaleHessianBasedObjectnessImage(const ITKMultiScaleHessianBasedObjectnessImage&) = delete; // Copy Constructor Not Implemented
   ITKMultiScaleHessianBasedObjectnessImage(ITKMultiScaleHessianBasedObjectnessImage&&) = delete;      // Move Constructor Not Implemented
   ITKMultiScaleHessianBasedObjectnessImage& operator=(const ITKMultiScaleHessianBasedObjectnessImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKNormalizeImage.h
+++ b/ITKImageProcessingFilters/ITKNormalizeImage.h
@@ -89,7 +89,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKNormalizeImage(const ITKNormalizeImage&) = delete;    // Copy Constructor Not Implemented
   ITKNormalizeImage(ITKNormalizeImage&&) = delete;         // Move Constructor Not Implemented
   ITKNormalizeImage& operator=(const ITKNormalizeImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKNormalizeToConstantImage.h
+++ b/ITKImageProcessingFilters/ITKNormalizeToConstantImage.h
@@ -96,7 +96,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKNormalizeToConstantImage(const ITKNormalizeToConstantImage&) = delete;    // Copy Constructor Not Implemented
   ITKNormalizeToConstantImage(ITKNormalizeToConstantImage&&) = delete;         // Move Constructor Not Implemented
   ITKNormalizeToConstantImage& operator=(const ITKNormalizeToConstantImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKNotImage.h
+++ b/ITKImageProcessingFilters/ITKNotImage.h
@@ -89,7 +89,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKNotImage(const ITKNotImage&) = delete;    // Copy Constructor Not Implemented
   ITKNotImage(ITKNotImage&&) = delete;         // Move Constructor Not Implemented
   ITKNotImage& operator=(const ITKNotImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKOpeningByReconstructionImage.h
+++ b/ITKImageProcessingFilters/ITKOpeningByReconstructionImage.h
@@ -110,7 +110,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKOpeningByReconstructionImage(const ITKOpeningByReconstructionImage&) = delete;    // Copy Constructor Not Implemented
   ITKOpeningByReconstructionImage(ITKOpeningByReconstructionImage&&) = delete;         // Move Constructor Not Implemented
   ITKOpeningByReconstructionImage& operator=(const ITKOpeningByReconstructionImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKOtsuMultipleThresholdsImage.h
+++ b/ITKImageProcessingFilters/ITKOtsuMultipleThresholdsImage.h
@@ -115,7 +115,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKOtsuMultipleThresholdsImage(const ITKOtsuMultipleThresholdsImage&) = delete;    // Copy Constructor Not Implemented
   ITKOtsuMultipleThresholdsImage(ITKOtsuMultipleThresholdsImage&&) = delete;         // Move Constructor Not Implemented
   ITKOtsuMultipleThresholdsImage& operator=(const ITKOtsuMultipleThresholdsImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKPatchBasedDenoisingImage.h
+++ b/ITKImageProcessingFilters/ITKPatchBasedDenoisingImage.h
@@ -147,7 +147,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKPatchBasedDenoisingImage(const ITKPatchBasedDenoisingImage&) = delete; // Copy Constructor Not Implemented
   ITKPatchBasedDenoisingImage(ITKPatchBasedDenoisingImage&&) = delete;      // Move Constructor Not Implemented
   ITKPatchBasedDenoisingImage& operator=(const ITKPatchBasedDenoisingImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKRGBToLuminanceImage.h
+++ b/ITKImageProcessingFilters/ITKRGBToLuminanceImage.h
@@ -87,7 +87,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKRGBToLuminanceImage(const ITKRGBToLuminanceImage&) = delete; // Copy Constructor Not Implemented
   ITKRGBToLuminanceImage(ITKRGBToLuminanceImage&&) = delete;      // Move Constructor Not Implemented
   ITKRGBToLuminanceImage& operator=(const ITKRGBToLuminanceImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKRegionalMaximaImage.h
+++ b/ITKImageProcessingFilters/ITKRegionalMaximaImage.h
@@ -109,7 +109,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKRegionalMaximaImage(const ITKRegionalMaximaImage&) = delete;    // Copy Constructor Not Implemented
   ITKRegionalMaximaImage(ITKRegionalMaximaImage&&) = delete;         // Move Constructor Not Implemented
   ITKRegionalMaximaImage& operator=(const ITKRegionalMaximaImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKRegionalMinimaImage.h
+++ b/ITKImageProcessingFilters/ITKRegionalMinimaImage.h
@@ -109,7 +109,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKRegionalMinimaImage(const ITKRegionalMinimaImage&) = delete;    // Copy Constructor Not Implemented
   ITKRegionalMinimaImage(ITKRegionalMinimaImage&&) = delete;         // Move Constructor Not Implemented
   ITKRegionalMinimaImage& operator=(const ITKRegionalMinimaImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKRelabelComponentImage.h
+++ b/ITKImageProcessingFilters/ITKRelabelComponentImage.h
@@ -118,7 +118,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKRelabelComponentImage(const ITKRelabelComponentImage&) = delete;    // Copy Constructor Not Implemented
   ITKRelabelComponentImage(ITKRelabelComponentImage&&) = delete;         // Move Constructor Not Implemented
   ITKRelabelComponentImage& operator=(const ITKRelabelComponentImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKRescaleIntensityImage.h
+++ b/ITKImageProcessingFilters/ITKRescaleIntensityImage.h
@@ -108,7 +108,7 @@ protected:
   */
   template <typename OutputPixelType> void CheckEntryBounds(double value, QString name);
 
-private:
+public:
   ITKRescaleIntensityImage(const ITKRescaleIntensityImage&) = delete;    // Copy Constructor Not Implemented
   ITKRescaleIntensityImage(ITKRescaleIntensityImage&&) = delete;         // Move Constructor Not Implemented
   ITKRescaleIntensityImage& operator=(const ITKRescaleIntensityImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKSaltAndPepperNoiseImage.h
+++ b/ITKImageProcessingFilters/ITKSaltAndPepperNoiseImage.h
@@ -100,7 +100,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKSaltAndPepperNoiseImage(const ITKSaltAndPepperNoiseImage&) = delete;    // Copy Constructor Not Implemented
   ITKSaltAndPepperNoiseImage(ITKSaltAndPepperNoiseImage&&) = delete;         // Move Constructor Not Implemented
   ITKSaltAndPepperNoiseImage& operator=(const ITKSaltAndPepperNoiseImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKShiftScaleImage.h
+++ b/ITKImageProcessingFilters/ITKShiftScaleImage.h
@@ -100,7 +100,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKShiftScaleImage(const ITKShiftScaleImage&) = delete;    // Copy Constructor Not Implemented
   ITKShiftScaleImage(ITKShiftScaleImage&&) = delete;         // Move Constructor Not Implemented
   ITKShiftScaleImage& operator=(const ITKShiftScaleImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKShotNoiseImage.h
+++ b/ITKImageProcessingFilters/ITKShotNoiseImage.h
@@ -100,7 +100,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKShotNoiseImage(const ITKShotNoiseImage&) = delete;    // Copy Constructor Not Implemented
   ITKShotNoiseImage(ITKShotNoiseImage&&) = delete;         // Move Constructor Not Implemented
   ITKShotNoiseImage& operator=(const ITKShotNoiseImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKSigmoidImage.h
+++ b/ITKImageProcessingFilters/ITKSigmoidImage.h
@@ -108,7 +108,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKSigmoidImage(const ITKSigmoidImage&) = delete;    // Copy Constructor Not Implemented
   ITKSigmoidImage(ITKSigmoidImage&&) = delete;         // Move Constructor Not Implemented
   ITKSigmoidImage& operator=(const ITKSigmoidImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKSignedDanielssonDistanceMapImage.h
+++ b/ITKImageProcessingFilters/ITKSignedDanielssonDistanceMapImage.h
@@ -104,7 +104,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKSignedDanielssonDistanceMapImage(const ITKSignedDanielssonDistanceMapImage&) = delete;    // Copy Constructor Not Implemented
   ITKSignedDanielssonDistanceMapImage(ITKSignedDanielssonDistanceMapImage&&) = delete;         // Move Constructor Not Implemented
   ITKSignedDanielssonDistanceMapImage& operator=(const ITKSignedDanielssonDistanceMapImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKSignedMaurerDistanceMapImage.h
+++ b/ITKImageProcessingFilters/ITKSignedMaurerDistanceMapImage.h
@@ -109,7 +109,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKSignedMaurerDistanceMapImage(const ITKSignedMaurerDistanceMapImage&) = delete;    // Copy Constructor Not Implemented
   ITKSignedMaurerDistanceMapImage(ITKSignedMaurerDistanceMapImage&&) = delete;         // Move Constructor Not Implemented
   ITKSignedMaurerDistanceMapImage& operator=(const ITKSignedMaurerDistanceMapImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKSinImage.h
+++ b/ITKImageProcessingFilters/ITKSinImage.h
@@ -89,7 +89,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKSinImage(const ITKSinImage&) = delete;    // Copy Constructor Not Implemented
   ITKSinImage(ITKSinImage&&) = delete;         // Move Constructor Not Implemented
   ITKSinImage& operator=(const ITKSinImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKSmoothingRecursiveGaussianImage.h
+++ b/ITKImageProcessingFilters/ITKSmoothingRecursiveGaussianImage.h
@@ -101,7 +101,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKSmoothingRecursiveGaussianImage(const ITKSmoothingRecursiveGaussianImage&) = delete;    // Copy Constructor Not Implemented
   ITKSmoothingRecursiveGaussianImage(ITKSmoothingRecursiveGaussianImage&&) = delete;         // Move Constructor Not Implemented
   ITKSmoothingRecursiveGaussianImage& operator=(const ITKSmoothingRecursiveGaussianImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKSobelEdgeDetectionImage.h
+++ b/ITKImageProcessingFilters/ITKSobelEdgeDetectionImage.h
@@ -89,7 +89,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKSobelEdgeDetectionImage(const ITKSobelEdgeDetectionImage&) = delete;    // Copy Constructor Not Implemented
   ITKSobelEdgeDetectionImage(ITKSobelEdgeDetectionImage&&) = delete;         // Move Constructor Not Implemented
   ITKSobelEdgeDetectionImage& operator=(const ITKSobelEdgeDetectionImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKSpeckleNoiseImage.h
+++ b/ITKImageProcessingFilters/ITKSpeckleNoiseImage.h
@@ -100,7 +100,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKSpeckleNoiseImage(const ITKSpeckleNoiseImage&) = delete;    // Copy Constructor Not Implemented
   ITKSpeckleNoiseImage(ITKSpeckleNoiseImage&&) = delete;         // Move Constructor Not Implemented
   ITKSpeckleNoiseImage& operator=(const ITKSpeckleNoiseImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKSqrtImage.h
+++ b/ITKImageProcessingFilters/ITKSqrtImage.h
@@ -89,7 +89,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKSqrtImage(const ITKSqrtImage&) = delete;    // Copy Constructor Not Implemented
   ITKSqrtImage(ITKSqrtImage&&) = delete;         // Move Constructor Not Implemented
   ITKSqrtImage& operator=(const ITKSqrtImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKSquareImage.h
+++ b/ITKImageProcessingFilters/ITKSquareImage.h
@@ -89,7 +89,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKSquareImage(const ITKSquareImage&) = delete;    // Copy Constructor Not Implemented
   ITKSquareImage(ITKSquareImage&&) = delete;         // Move Constructor Not Implemented
   ITKSquareImage& operator=(const ITKSquareImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKStandardDeviationProjectionImage.h
+++ b/ITKImageProcessingFilters/ITKStandardDeviationProjectionImage.h
@@ -96,7 +96,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKStandardDeviationProjectionImage(const ITKStandardDeviationProjectionImage&) = delete;    // Copy Constructor Not Implemented
   ITKStandardDeviationProjectionImage(ITKStandardDeviationProjectionImage&&) = delete;         // Move Constructor Not Implemented
   ITKStandardDeviationProjectionImage& operator=(const ITKStandardDeviationProjectionImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKSumProjectionImage.h
+++ b/ITKImageProcessingFilters/ITKSumProjectionImage.h
@@ -96,7 +96,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKSumProjectionImage(const ITKSumProjectionImage&) = delete;    // Copy Constructor Not Implemented
   ITKSumProjectionImage(ITKSumProjectionImage&&) = delete;         // Move Constructor Not Implemented
   ITKSumProjectionImage& operator=(const ITKSumProjectionImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKTanImage.h
+++ b/ITKImageProcessingFilters/ITKTanImage.h
@@ -89,7 +89,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKTanImage(const ITKTanImage&) = delete;    // Copy Constructor Not Implemented
   ITKTanImage(ITKTanImage&&) = delete;         // Move Constructor Not Implemented
   ITKTanImage& operator=(const ITKTanImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKThresholdImage.h
+++ b/ITKImageProcessingFilters/ITKThresholdImage.h
@@ -104,7 +104,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKThresholdImage(const ITKThresholdImage&) = delete;    // Copy Constructor Not Implemented
   ITKThresholdImage(ITKThresholdImage&&) = delete;         // Move Constructor Not Implemented
   ITKThresholdImage& operator=(const ITKThresholdImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKThresholdMaximumConnectedComponentsImage.h
+++ b/ITKImageProcessingFilters/ITKThresholdMaximumConnectedComponentsImage.h
@@ -109,7 +109,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKThresholdMaximumConnectedComponentsImage(const ITKThresholdMaximumConnectedComponentsImage&) = delete;    // Copy Constructor Not Implemented
   ITKThresholdMaximumConnectedComponentsImage(ITKThresholdMaximumConnectedComponentsImage&&) = delete;         // Move Constructor Not Implemented
   ITKThresholdMaximumConnectedComponentsImage& operator=(const ITKThresholdMaximumConnectedComponentsImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKValuedRegionalMaximaImage.h
+++ b/ITKImageProcessingFilters/ITKValuedRegionalMaximaImage.h
@@ -100,7 +100,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKValuedRegionalMaximaImage(const ITKValuedRegionalMaximaImage&) = delete;    // Copy Constructor Not Implemented
   ITKValuedRegionalMaximaImage(ITKValuedRegionalMaximaImage&&) = delete;         // Move Constructor Not Implemented
   ITKValuedRegionalMaximaImage& operator=(const ITKValuedRegionalMaximaImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKValuedRegionalMinimaImage.h
+++ b/ITKImageProcessingFilters/ITKValuedRegionalMinimaImage.h
@@ -100,7 +100,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKValuedRegionalMinimaImage(const ITKValuedRegionalMinimaImage&) = delete;    // Copy Constructor Not Implemented
   ITKValuedRegionalMinimaImage(ITKValuedRegionalMinimaImage&&) = delete;         // Move Constructor Not Implemented
   ITKValuedRegionalMinimaImage& operator=(const ITKValuedRegionalMinimaImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKVectorConnectedComponentImage.h
+++ b/ITKImageProcessingFilters/ITKVectorConnectedComponentImage.h
@@ -101,7 +101,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKVectorConnectedComponentImage(const ITKVectorConnectedComponentImage&) = delete;    // Copy Constructor Not Implemented
   ITKVectorConnectedComponentImage(ITKVectorConnectedComponentImage&&) = delete;         // Move Constructor Not Implemented
   ITKVectorConnectedComponentImage& operator=(const ITKVectorConnectedComponentImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKVectorRescaleIntensityImage.h
+++ b/ITKImageProcessingFilters/ITKVectorRescaleIntensityImage.h
@@ -104,7 +104,7 @@ protected:
   */
   template <typename OutputPixelType> void CheckEntryBounds(double value, QString name);
 
-private:
+public:
   ITKVectorRescaleIntensityImage(const ITKVectorRescaleIntensityImage&) = delete; // Copy Constructor Not Implemented
   ITKVectorRescaleIntensityImage(ITKVectorRescaleIntensityImage&&) = delete;      // Move Constructor Not Implemented
   ITKVectorRescaleIntensityImage& operator=(const ITKVectorRescaleIntensityImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKWhiteTopHatImage.h
+++ b/ITKImageProcessingFilters/ITKWhiteTopHatImage.h
@@ -106,7 +106,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKWhiteTopHatImage(const ITKWhiteTopHatImage&) = delete;    // Copy Constructor Not Implemented
   ITKWhiteTopHatImage(ITKWhiteTopHatImage&&) = delete;         // Move Constructor Not Implemented
   ITKWhiteTopHatImage& operator=(const ITKWhiteTopHatImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ITKZeroCrossingImage.h
+++ b/ITKImageProcessingFilters/ITKZeroCrossingImage.h
@@ -100,7 +100,7 @@ protected:
   */
   template <typename InputImageType, typename OutputImageType, unsigned int Dimension> void filter();
 
-private:
+public:
   ITKZeroCrossingImage(const ITKZeroCrossingImage&) = delete;    // Copy Constructor Not Implemented
   ITKZeroCrossingImage(ITKZeroCrossingImage&&) = delete;         // Move Constructor Not Implemented
   ITKZeroCrossingImage& operator=(const ITKZeroCrossingImage&) = delete; // Copy Assignment Not Implemented

--- a/ITKImageProcessingFilters/ImportImageMontage.h
+++ b/ITKImageProcessingFilters/ImportImageMontage.h
@@ -110,7 +110,7 @@ public:
   /**
    * @brief readFilterParameters Reimplemented from @see AbstractFilter class
    */
-  void readFilterParameters(AbstractFilterParametersReader* reader, int index);
+  void readFilterParameters(AbstractFilterParametersReader* reader, int index) override;
 
   /**
    * @brief execute Reimplemented from @see AbstractFilter class
@@ -180,7 +180,8 @@ private:
    */
   ITK_IMAGE_READER_HELPER_ImageDataArrayName() ITK_IMAGE_READER_HELPER_DECL()
 
-      public : ImportImageMontage(const ImportImageMontage&) = delete; // Copy Constructor Not Implemented
+public:
+  ImportImageMontage(const ImportImageMontage&) = delete; // Copy Constructor Not Implemented
   ImportImageMontage(ImportImageMontage&&) = delete;                   // Move Constructor Not Implemented
   ImportImageMontage& operator=(const ImportImageMontage&) = delete;   // Copy Assignment Not Implemented
   ImportImageMontage& operator=(ImportImageMontage&&) = delete;        // Move Assignment Not Implemented

--- a/ITKImageProcessingFilters/ImportRegisteredImageMontage.h
+++ b/ITKImageProcessingFilters/ImportRegisteredImageMontage.h
@@ -122,7 +122,7 @@ public:
   /**
    * @brief readFilterParameters Reimplemented from @see AbstractFilter class
    */
-  void readFilterParameters(AbstractFilterParametersReader* reader, int index);
+  void readFilterParameters(AbstractFilterParametersReader* reader, int index) override;
 
   /**
    * @brief execute Reimplemented from @see AbstractFilter class
@@ -192,7 +192,8 @@ private:
    */
   ITK_IMAGE_READER_HELPER_ImageDataArrayName() ITK_IMAGE_READER_HELPER_DECL()
 
-      public : ImportRegisteredImageMontage(const ImportRegisteredImageMontage&) = delete; // Copy Constructor Not Implemented
+public :
+  ImportRegisteredImageMontage(const ImportRegisteredImageMontage&) = delete; // Copy Constructor Not Implemented
   ImportRegisteredImageMontage(ImportRegisteredImageMontage&&) = delete;                   // Move Constructor Not Implemented
   ImportRegisteredImageMontage& operator=(const ImportRegisteredImageMontage&) = delete;   // Copy Assignment Not Implemented
   ImportRegisteredImageMontage& operator=(ImportRegisteredImageMontage&&) = delete;        // Move Assignment Not Implemented

--- a/ITKImageProcessingFilters/ImportVectorImageStack.h
+++ b/ITKImageProcessingFilters/ImportVectorImageStack.h
@@ -196,7 +196,6 @@ protected:
    */
   void generateFileList();
 
-private:
 public:
   ImportVectorImageStack(const ImportVectorImageStack&) = delete;            // Copy Constructor Not Implemented
   ImportVectorImageStack(ImportVectorImageStack&&) = delete;                 // Move Constructor Not Implemented

--- a/ITKImageProcessingPlugin.h
+++ b/ITKImageProcessingPlugin.h
@@ -207,6 +207,6 @@ private:
   bool m_DidLoad;
 
   ITKImageProcessingPlugin(const ITKImageProcessingPlugin&) = delete; // Copy Constructor Not Implemented
-  void operator=(const ITKImageProcessingPlugin&);                    // Move assignment Not Implemented
+  void operator=(const ITKImageProcessingPlugin&) = delete;           // Move assignment Not Implemented
 };
 

--- a/Test/ITKTestBase.h
+++ b/Test/ITKTestBase.h
@@ -521,7 +521,7 @@ protected:
   QList<QString> FilesToRemove;
 
 private:
-  ITKTestBase(const ITKTestBase&);    // Copy Constructor Not Implemented
+  ITKTestBase(const ITKTestBase&) = delete;    // Copy Constructor Not Implemented
   void operator=(const ITKTestBase&) = delete; // Move assignment Not Implemented
 };
 


### PR DESCRIPTION
Classes are updated to use C++11 standard '=delete' or '=default' for each of
the copy and move constructors and copy and move assignments.

Other misc formatting updates to any affected classes.

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>