### PR TITLE
Use clang tidy to update codes for readability.

### DIFF
--- a/FilterParameters/ImportVectorImageStackFilterParameter.cpp
+++ b/FilterParameters/ImportVectorImageStackFilterParameter.cpp
@@ -41,10 +41,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-ImportVectorImageStackFilterParameter::ImportVectorImageStackFilterParameter()
-: FilterParameter()
-{
-}
+ImportVectorImageStackFilterParameter::ImportVectorImageStackFilterParameter() = default;
 
 // -----------------------------------------------------------------------------
 //

--- a/Gui/FilterParameterWidgets/ImportVectorImageStackWidget.cpp
+++ b/Gui/FilterParameterWidgets/ImportVectorImageStackWidget.cpp
@@ -273,7 +273,7 @@ void ImportVectorImageStackWidget::setupMenuField()
     connect(m_ShowFileAction, SIGNAL(triggered()), this, SLOT(showFileInFileSystem()));
   }
 
-  if(m_Ui->inputDir->text().isEmpty() == false && fi.exists())
+  if(!m_Ui->inputDir->text().isEmpty() && fi.exists())
   {
     m_ShowFileAction->setEnabled(true);
   }
@@ -322,14 +322,14 @@ void ImportVectorImageStackWidget::validateInputFile()
 
   QString currentPath = data.InputPath;
   QFileInfo fi(currentPath);
-  if(currentPath.isEmpty() == false && fi.exists() == false)
+  if(!currentPath.isEmpty() && !fi.exists())
   {
     QString defaultName = m_OpenDialogLastFilePath;
 
     QString title = QObject::tr("Select a replacement input file in filter '%2'").arg(getFilter()->getHumanLabel());
 
     QString file = QFileDialog::getExistingDirectory(this, title, getInputDirectory(), QFileDialog::ShowDirsOnly);
-    if(true == file.isEmpty())
+    if(file.isEmpty())
     {
       file = currentPath;
     }
@@ -355,7 +355,7 @@ void ImportVectorImageStackWidget::validateInputFile()
 // -----------------------------------------------------------------------------
 void ImportVectorImageStackWidget::checkIOFiles()
 {
-  if(true == this->verifyPathExists(m_Ui->inputDir->text(), m_Ui->inputDir))
+  if(this->verifyPathExists(m_Ui->inputDir->text(), m_Ui->inputDir))
   {
     findMaxSliceAndPrefix();
   }
@@ -466,7 +466,7 @@ void ImportVectorImageStackWidget::generateExampleInputFile()
     QString filePath(fileList.at(i));
     QFileInfo fi(filePath);
     QListWidgetItem* item = new QListWidgetItem(filePath, m_Ui->fileListView);
-    if(fi.exists() == true)
+    if(fi.exists())
     {
       item->setIcon(greenDot);
       foundFileCount++;
@@ -481,8 +481,12 @@ void ImportVectorImageStackWidget::generateExampleInputFile()
 
   QString eMsg("Please make sure all files exist");
   m_Ui->errorMessage->setVisible(true);
-  QString msg =
-      QString("%1 File%2 Found  ||  %3 File%4 Missing. %5").arg(foundFileCount).arg(foundFileCount ? "s" : "").arg(missingFileCount).arg(missingFileCount ? "s" : "").arg(hasMissingFiles ? eMsg : "");
+  QString msg = QString("%1 File%2 Found  ||  %3 File%4 Missing. %5")
+                    .arg(foundFileCount)
+                    .arg(foundFileCount != 0 ? "s" : "")
+                    .arg(missingFileCount)
+                    .arg(missingFileCount != 0 ? "s" : "")
+                    .arg(hasMissingFiles ? eMsg : "");
   m_Ui->errorMessage->setText(msg);
 }
 
@@ -498,7 +502,7 @@ void ImportVectorImageStackWidget::findMaxSliceAndPrefix()
   QDir dir(m_Ui->inputDir->text());
 
   // Final check to make sure we have a valid file extension
-  if(m_Ui->fileExt->text().isEmpty() == true)
+  if(m_Ui->fileExt->text().isEmpty())
   {
     return;
   }
@@ -524,7 +528,7 @@ void ImportVectorImageStackWidget::findMaxSliceAndPrefix()
   int minTotalDigits = 1000;
   foreach(QFileInfo fi, angList)
   {
-    if(fi.suffix().compare(ext) && fi.isFile() == true)
+    if((fi.suffix().compare(ext) != 0) && fi.isFile())
     {
       pos = 0;
       list.clear();
@@ -556,10 +560,10 @@ void ImportVectorImageStackWidget::findMaxSliceAndPrefix()
         minTotalDigits = digitEnd - digitStart;
       }
       m_Ui->totalDigits->setValue(minTotalDigits);
-      if(list.size() > 0)
+      if(!list.empty())
       {
         currValue = list.front().toInt(&ok);
-        if(false == flag)
+        if(!flag)
         {
           minSlice = currValue;
           flag = true;
@@ -621,7 +625,7 @@ void ImportVectorImageStackWidget::filterNeedsInputParameters(AbstractFilter* fi
   QVariant v;
   v.setValue(data);
   ok = filter->setProperty(PROPERTY_NAME_AS_CHAR, v);
-  if(false == ok)
+  if(!ok)
   {
     getFilter()->notifyMissingProperty(getFilterParameter());
   }
@@ -632,7 +636,7 @@ void ImportVectorImageStackWidget::filterNeedsInputParameters(AbstractFilter* fi
 // -----------------------------------------------------------------------------
 void ImportVectorImageStackWidget::beforePreflight()
 {
-  if(m_DidCausePreflight == false)
+  if(!m_DidCausePreflight)
   {
   }
 }

--- a/Gui/ITKImageProcessingGuiPlugin.cpp
+++ b/Gui/ITKImageProcessingGuiPlugin.cpp
@@ -5,10 +5,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-ITKImageProcessingGuiPlugin::ITKImageProcessingGuiPlugin()
-: ITKImageProcessingPlugin()
-{
-}
+ITKImageProcessingGuiPlugin::ITKImageProcessingGuiPlugin() = default;
 
 // -----------------------------------------------------------------------------
 //

--- a/ITKImageProcessingFilters/ITKAbsImage.cpp
+++ b/ITKImageProcessingFilters/ITKAbsImage.cpp
@@ -22,10 +22,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-ITKAbsImage::ITKAbsImage()
-{
-
-}
+ITKAbsImage::ITKAbsImage() = default;
 
 // -----------------------------------------------------------------------------
 //
@@ -119,7 +116,7 @@ void ITKAbsImage::filterInternal()
 AbstractFilter::Pointer ITKAbsImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKAbsImage::Pointer filter = ITKAbsImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKAcosImage.cpp
+++ b/ITKImageProcessingFilters/ITKAcosImage.cpp
@@ -22,10 +22,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-ITKAcosImage::ITKAcosImage()
-{
-
-}
+ITKAcosImage::ITKAcosImage() = default;
 
 // -----------------------------------------------------------------------------
 //
@@ -119,7 +116,7 @@ void ITKAcosImage::filterInternal()
 AbstractFilter::Pointer ITKAcosImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKAcosImage::Pointer filter = ITKAcosImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKAdaptiveHistogramEqualizationImage.cpp
+++ b/ITKImageProcessingFilters/ITKAdaptiveHistogramEqualizationImage.cpp
@@ -132,7 +132,7 @@ void ITKAdaptiveHistogramEqualizationImage::filterInternal()
 AbstractFilter::Pointer ITKAdaptiveHistogramEqualizationImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKAdaptiveHistogramEqualizationImage::Pointer filter = ITKAdaptiveHistogramEqualizationImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKApproximateSignedDistanceMapImage.cpp
+++ b/ITKImageProcessingFilters/ITKApproximateSignedDistanceMapImage.cpp
@@ -127,7 +127,7 @@ void ITKApproximateSignedDistanceMapImage::filterInternal()
 AbstractFilter::Pointer ITKApproximateSignedDistanceMapImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKApproximateSignedDistanceMapImage::Pointer filter = ITKApproximateSignedDistanceMapImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKAsinImage.cpp
+++ b/ITKImageProcessingFilters/ITKAsinImage.cpp
@@ -22,10 +22,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-ITKAsinImage::ITKAsinImage()
-{
-
-}
+ITKAsinImage::ITKAsinImage() = default;
 
 // -----------------------------------------------------------------------------
 //
@@ -119,7 +116,7 @@ void ITKAsinImage::filterInternal()
 AbstractFilter::Pointer ITKAsinImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKAsinImage::Pointer filter = ITKAsinImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKAtanImage.cpp
+++ b/ITKImageProcessingFilters/ITKAtanImage.cpp
@@ -22,10 +22,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-ITKAtanImage::ITKAtanImage()
-{
-
-}
+ITKAtanImage::ITKAtanImage() = default;
 
 // -----------------------------------------------------------------------------
 //
@@ -119,7 +116,7 @@ void ITKAtanImage::filterInternal()
 AbstractFilter::Pointer ITKAtanImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKAtanImage::Pointer filter = ITKAtanImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKBilateralImage.cpp
+++ b/ITKImageProcessingFilters/ITKBilateralImage.cpp
@@ -132,7 +132,7 @@ void ITKBilateralImage::filterInternal()
 AbstractFilter::Pointer ITKBilateralImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKBilateralImage::Pointer filter = ITKBilateralImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKBinaryClosingByReconstructionImage.cpp
+++ b/ITKImageProcessingFilters/ITKBinaryClosingByReconstructionImage.cpp
@@ -189,7 +189,7 @@ void ITKBinaryClosingByReconstructionImage::filterInternal()
 AbstractFilter::Pointer ITKBinaryClosingByReconstructionImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKBinaryClosingByReconstructionImage::Pointer filter = ITKBinaryClosingByReconstructionImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKBinaryContourImage.cpp
+++ b/ITKImageProcessingFilters/ITKBinaryContourImage.cpp
@@ -131,7 +131,7 @@ void ITKBinaryContourImage::filterInternal()
 AbstractFilter::Pointer ITKBinaryContourImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKBinaryContourImage::Pointer filter = ITKBinaryContourImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKBinaryDilateImage.cpp
+++ b/ITKImageProcessingFilters/ITKBinaryDilateImage.cpp
@@ -192,7 +192,7 @@ void ITKBinaryDilateImage::filterInternal()
 AbstractFilter::Pointer ITKBinaryDilateImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKBinaryDilateImage::Pointer filter = ITKBinaryDilateImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKBinaryErodeImage.cpp
+++ b/ITKImageProcessingFilters/ITKBinaryErodeImage.cpp
@@ -193,7 +193,7 @@ void ITKBinaryErodeImage::filterInternal()
 AbstractFilter::Pointer ITKBinaryErodeImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKBinaryErodeImage::Pointer filter = ITKBinaryErodeImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKBinaryMorphologicalClosingImage.cpp
+++ b/ITKImageProcessingFilters/ITKBinaryMorphologicalClosingImage.cpp
@@ -189,7 +189,7 @@ void ITKBinaryMorphologicalClosingImage::filterInternal()
 AbstractFilter::Pointer ITKBinaryMorphologicalClosingImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKBinaryMorphologicalClosingImage::Pointer filter = ITKBinaryMorphologicalClosingImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKBinaryMorphologicalOpeningImage.cpp
+++ b/ITKImageProcessingFilters/ITKBinaryMorphologicalOpeningImage.cpp
@@ -189,7 +189,7 @@ void ITKBinaryMorphologicalOpeningImage::filterInternal()
 AbstractFilter::Pointer ITKBinaryMorphologicalOpeningImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKBinaryMorphologicalOpeningImage::Pointer filter = ITKBinaryMorphologicalOpeningImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKBinaryOpeningByReconstructionImage.cpp
+++ b/ITKImageProcessingFilters/ITKBinaryOpeningByReconstructionImage.cpp
@@ -193,7 +193,7 @@ void ITKBinaryOpeningByReconstructionImage::filterInternal()
 AbstractFilter::Pointer ITKBinaryOpeningByReconstructionImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKBinaryOpeningByReconstructionImage::Pointer filter = ITKBinaryOpeningByReconstructionImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKBinaryProjectionImage.cpp
+++ b/ITKImageProcessingFilters/ITKBinaryProjectionImage.cpp
@@ -132,7 +132,7 @@ void ITKBinaryProjectionImage::filterInternal()
 AbstractFilter::Pointer ITKBinaryProjectionImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKBinaryProjectionImage::Pointer filter = ITKBinaryProjectionImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKBinaryThinningImage.cpp
+++ b/ITKImageProcessingFilters/ITKBinaryThinningImage.cpp
@@ -22,10 +22,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-ITKBinaryThinningImage::ITKBinaryThinningImage()
-{
-
-}
+ITKBinaryThinningImage::ITKBinaryThinningImage() = default;
 
 // -----------------------------------------------------------------------------
 //
@@ -119,7 +116,7 @@ void ITKBinaryThinningImage::filterInternal()
 AbstractFilter::Pointer ITKBinaryThinningImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKBinaryThinningImage::Pointer filter = ITKBinaryThinningImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKBinaryThresholdImage.cpp
+++ b/ITKImageProcessingFilters/ITKBinaryThresholdImage.cpp
@@ -137,7 +137,7 @@ void ITKBinaryThresholdImage::filterInternal()
 AbstractFilter::Pointer ITKBinaryThresholdImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKBinaryThresholdImage::Pointer filter = ITKBinaryThresholdImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKBinomialBlurImage.cpp
+++ b/ITKImageProcessingFilters/ITKBinomialBlurImage.cpp
@@ -124,7 +124,7 @@ void ITKBinomialBlurImage::filterInternal()
 AbstractFilter::Pointer ITKBinomialBlurImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKBinomialBlurImage::Pointer filter = ITKBinomialBlurImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKBlackTopHatImage.cpp
+++ b/ITKImageProcessingFilters/ITKBlackTopHatImage.cpp
@@ -174,7 +174,7 @@ void ITKBlackTopHatImage::filterInternal()
 AbstractFilter::Pointer ITKBlackTopHatImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKBlackTopHatImage::Pointer filter = ITKBlackTopHatImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKBoundedReciprocalImage.cpp
+++ b/ITKImageProcessingFilters/ITKBoundedReciprocalImage.cpp
@@ -22,10 +22,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-ITKBoundedReciprocalImage::ITKBoundedReciprocalImage()
-{
-
-}
+ITKBoundedReciprocalImage::ITKBoundedReciprocalImage() = default;
 
 // -----------------------------------------------------------------------------
 //
@@ -119,7 +116,7 @@ void ITKBoundedReciprocalImage::filterInternal()
 AbstractFilter::Pointer ITKBoundedReciprocalImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKBoundedReciprocalImage::Pointer filter = ITKBoundedReciprocalImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKBoxMeanImage.cpp
+++ b/ITKImageProcessingFilters/ITKBoxMeanImage.cpp
@@ -124,7 +124,7 @@ void ITKBoxMeanImage::filterInternal()
 AbstractFilter::Pointer ITKBoxMeanImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKBoxMeanImage::Pointer filter = ITKBoxMeanImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKCastImage.cpp
+++ b/ITKImageProcessingFilters/ITKCastImage.cpp
@@ -144,7 +144,7 @@ void ITKCastImage::filterInternal()
 AbstractFilter::Pointer ITKCastImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKCastImage::Pointer filter = ITKCastImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKClosingByReconstructionImage.cpp
+++ b/ITKImageProcessingFilters/ITKClosingByReconstructionImage.cpp
@@ -178,7 +178,7 @@ void ITKClosingByReconstructionImage::filterInternal()
 AbstractFilter::Pointer ITKClosingByReconstructionImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKClosingByReconstructionImage::Pointer filter = ITKClosingByReconstructionImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKConnectedComponentImage.cpp
+++ b/ITKImageProcessingFilters/ITKConnectedComponentImage.cpp
@@ -128,7 +128,7 @@ void ITKConnectedComponentImage::filterInternal()
 AbstractFilter::Pointer ITKConnectedComponentImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKConnectedComponentImage::Pointer filter = ITKConnectedComponentImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKCosImage.cpp
+++ b/ITKImageProcessingFilters/ITKCosImage.cpp
@@ -22,10 +22,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-ITKCosImage::ITKCosImage()
-{
-
-}
+ITKCosImage::ITKCosImage() = default;
 
 // -----------------------------------------------------------------------------
 //
@@ -119,7 +116,7 @@ void ITKCosImage::filterInternal()
 AbstractFilter::Pointer ITKCosImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKCosImage::Pointer filter = ITKCosImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKCurvatureAnisotropicDiffusionImage.cpp
+++ b/ITKImageProcessingFilters/ITKCurvatureAnisotropicDiffusionImage.cpp
@@ -137,7 +137,7 @@ void ITKCurvatureAnisotropicDiffusionImage::filterInternal()
 AbstractFilter::Pointer ITKCurvatureAnisotropicDiffusionImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKCurvatureAnisotropicDiffusionImage::Pointer filter = ITKCurvatureAnisotropicDiffusionImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKCurvatureFlowImage.cpp
+++ b/ITKImageProcessingFilters/ITKCurvatureFlowImage.cpp
@@ -128,7 +128,7 @@ void ITKCurvatureFlowImage::filterInternal()
 AbstractFilter::Pointer ITKCurvatureFlowImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKCurvatureFlowImage::Pointer filter = ITKCurvatureFlowImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKDanielssonDistanceMapImage.cpp
+++ b/ITKImageProcessingFilters/ITKDanielssonDistanceMapImage.cpp
@@ -131,7 +131,7 @@ void ITKDanielssonDistanceMapImage::filterInternal()
 AbstractFilter::Pointer ITKDanielssonDistanceMapImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKDanielssonDistanceMapImage::Pointer filter = ITKDanielssonDistanceMapImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKDilateObjectMorphologyImage.cpp
+++ b/ITKImageProcessingFilters/ITKDilateObjectMorphologyImage.cpp
@@ -174,7 +174,7 @@ void ITKDilateObjectMorphologyImage::filterInternal()
 AbstractFilter::Pointer ITKDilateObjectMorphologyImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKDilateObjectMorphologyImage::Pointer filter = ITKDilateObjectMorphologyImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKDiscreteGaussianImage.cpp
+++ b/ITKImageProcessingFilters/ITKDiscreteGaussianImage.cpp
@@ -138,7 +138,7 @@ void ITKDiscreteGaussianImage::filterInternal()
 AbstractFilter::Pointer ITKDiscreteGaussianImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKDiscreteGaussianImage::Pointer filter = ITKDiscreteGaussianImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKDoubleThresholdImage.cpp
+++ b/ITKImageProcessingFilters/ITKDoubleThresholdImage.cpp
@@ -149,7 +149,7 @@ void ITKDoubleThresholdImage::filterInternal()
 AbstractFilter::Pointer ITKDoubleThresholdImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKDoubleThresholdImage::Pointer filter = ITKDoubleThresholdImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKErodeObjectMorphologyImage.cpp
+++ b/ITKImageProcessingFilters/ITKErodeObjectMorphologyImage.cpp
@@ -178,7 +178,7 @@ void ITKErodeObjectMorphologyImage::filterInternal()
 AbstractFilter::Pointer ITKErodeObjectMorphologyImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKErodeObjectMorphologyImage::Pointer filter = ITKErodeObjectMorphologyImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKExpImage.cpp
+++ b/ITKImageProcessingFilters/ITKExpImage.cpp
@@ -22,10 +22,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-ITKExpImage::ITKExpImage()
-{
-
-}
+ITKExpImage::ITKExpImage() = default;
 
 // -----------------------------------------------------------------------------
 //
@@ -119,7 +116,7 @@ void ITKExpImage::filterInternal()
 AbstractFilter::Pointer ITKExpImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKExpImage::Pointer filter = ITKExpImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKExpNegativeImage.cpp
+++ b/ITKImageProcessingFilters/ITKExpNegativeImage.cpp
@@ -22,10 +22,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-ITKExpNegativeImage::ITKExpNegativeImage()
-{
-
-}
+ITKExpNegativeImage::ITKExpNegativeImage() = default;
 
 // -----------------------------------------------------------------------------
 //
@@ -119,7 +116,7 @@ void ITKExpNegativeImage::filterInternal()
 AbstractFilter::Pointer ITKExpNegativeImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKExpNegativeImage::Pointer filter = ITKExpNegativeImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKFFTNormalizedCorrelationImage.cpp
+++ b/ITKImageProcessingFilters/ITKFFTNormalizedCorrelationImage.cpp
@@ -189,7 +189,7 @@ void ITKFFTNormalizedCorrelationImage::filterInternal()
 AbstractFilter::Pointer ITKFFTNormalizedCorrelationImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKFFTNormalizedCorrelationImage::Pointer filter = ITKFFTNormalizedCorrelationImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKGradientAnisotropicDiffusionImage.cpp
+++ b/ITKImageProcessingFilters/ITKGradientAnisotropicDiffusionImage.cpp
@@ -137,7 +137,7 @@ void ITKGradientAnisotropicDiffusionImage::filterInternal()
 AbstractFilter::Pointer ITKGradientAnisotropicDiffusionImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKGradientAnisotropicDiffusionImage::Pointer filter = ITKGradientAnisotropicDiffusionImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKGradientMagnitudeImage.cpp
+++ b/ITKImageProcessingFilters/ITKGradientMagnitudeImage.cpp
@@ -123,7 +123,7 @@ void ITKGradientMagnitudeImage::filterInternal()
 AbstractFilter::Pointer ITKGradientMagnitudeImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKGradientMagnitudeImage::Pointer filter = ITKGradientMagnitudeImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKGradientMagnitudeRecursiveGaussianImage.cpp
+++ b/ITKImageProcessingFilters/ITKGradientMagnitudeRecursiveGaussianImage.cpp
@@ -127,7 +127,7 @@ void ITKGradientMagnitudeRecursiveGaussianImage::filterInternal()
 AbstractFilter::Pointer ITKGradientMagnitudeRecursiveGaussianImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKGradientMagnitudeRecursiveGaussianImage::Pointer filter = ITKGradientMagnitudeRecursiveGaussianImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKGrayscaleDilateImage.cpp
+++ b/ITKImageProcessingFilters/ITKGrayscaleDilateImage.cpp
@@ -170,7 +170,7 @@ void ITKGrayscaleDilateImage::filterInternal()
 AbstractFilter::Pointer ITKGrayscaleDilateImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKGrayscaleDilateImage::Pointer filter = ITKGrayscaleDilateImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKGrayscaleErodeImage.cpp
+++ b/ITKImageProcessingFilters/ITKGrayscaleErodeImage.cpp
@@ -170,7 +170,7 @@ void ITKGrayscaleErodeImage::filterInternal()
 AbstractFilter::Pointer ITKGrayscaleErodeImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKGrayscaleErodeImage::Pointer filter = ITKGrayscaleErodeImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKGrayscaleFillholeImage.cpp
+++ b/ITKImageProcessingFilters/ITKGrayscaleFillholeImage.cpp
@@ -123,7 +123,7 @@ void ITKGrayscaleFillholeImage::filterInternal()
 AbstractFilter::Pointer ITKGrayscaleFillholeImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKGrayscaleFillholeImage::Pointer filter = ITKGrayscaleFillholeImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKGrayscaleGrindPeakImage.cpp
+++ b/ITKImageProcessingFilters/ITKGrayscaleGrindPeakImage.cpp
@@ -123,7 +123,7 @@ void ITKGrayscaleGrindPeakImage::filterInternal()
 AbstractFilter::Pointer ITKGrayscaleGrindPeakImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKGrayscaleGrindPeakImage::Pointer filter = ITKGrayscaleGrindPeakImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKGrayscaleMorphologicalClosingImage.cpp
+++ b/ITKImageProcessingFilters/ITKGrayscaleMorphologicalClosingImage.cpp
@@ -174,7 +174,7 @@ void ITKGrayscaleMorphologicalClosingImage::filterInternal()
 AbstractFilter::Pointer ITKGrayscaleMorphologicalClosingImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKGrayscaleMorphologicalClosingImage::Pointer filter = ITKGrayscaleMorphologicalClosingImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKGrayscaleMorphologicalOpeningImage.cpp
+++ b/ITKImageProcessingFilters/ITKGrayscaleMorphologicalOpeningImage.cpp
@@ -174,7 +174,7 @@ void ITKGrayscaleMorphologicalOpeningImage::filterInternal()
 AbstractFilter::Pointer ITKGrayscaleMorphologicalOpeningImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKGrayscaleMorphologicalOpeningImage::Pointer filter = ITKGrayscaleMorphologicalOpeningImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKHConvexImage.cpp
+++ b/ITKImageProcessingFilters/ITKHConvexImage.cpp
@@ -127,7 +127,7 @@ void ITKHConvexImage::filterInternal()
 AbstractFilter::Pointer ITKHConvexImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKHConvexImage::Pointer filter = ITKHConvexImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKHMaximaImage.cpp
+++ b/ITKImageProcessingFilters/ITKHMaximaImage.cpp
@@ -123,7 +123,7 @@ void ITKHMaximaImage::filterInternal()
 AbstractFilter::Pointer ITKHMaximaImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKHMaximaImage::Pointer filter = ITKHMaximaImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKHMinimaImage.cpp
+++ b/ITKImageProcessingFilters/ITKHMinimaImage.cpp
@@ -127,7 +127,7 @@ void ITKHMinimaImage::filterInternal()
 AbstractFilter::Pointer ITKHMinimaImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKHMinimaImage::Pointer filter = ITKHMinimaImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKHistogramMatchingImage.cpp
+++ b/ITKImageProcessingFilters/ITKHistogramMatchingImage.cpp
@@ -165,7 +165,7 @@ void ITKHistogramMatchingImage::CompareImagePixelTypes(const DataArrayPath& path
 void ITKHistogramMatchingImage::CompareImageTypes(const DataArrayPath& path1, const DataArrayPath& path2)
 {
   // Does data array exist
-  if(CheckArrayExists(path1) || CheckArrayExists(path2))
+  if((CheckArrayExists(path1) != 0) || (CheckArrayExists(path2) != 0))
   {
     return;
   }
@@ -251,7 +251,7 @@ void ITKHistogramMatchingImage::filterInternal()
 AbstractFilter::Pointer ITKHistogramMatchingImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKHistogramMatchingImage::Pointer filter = ITKHistogramMatchingImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKImageProcessingBase.cpp
+++ b/ITKImageProcessingFilters/ITKImageProcessingBase.cpp
@@ -8,9 +8,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-ITKImageProcessingBase::ITKImageProcessingBase()
-{
-}
+ITKImageProcessingBase::ITKImageProcessingBase() = default;
 
 // -----------------------------------------------------------------------------
 //
@@ -65,7 +63,7 @@ const QString ITKImageProcessingBase::getGroupName() const
 AbstractFilter::Pointer ITKImageProcessingBase::newFilterInstance(bool copyFilterParameters) const
 {
   ITKImageProcessingBase::Pointer filter = ITKImageProcessingBase::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKImageReader.cpp
+++ b/ITKImageProcessingFilters/ITKImageReader.cpp
@@ -114,7 +114,7 @@ void ITKImageReader::dataCheck()
   }
 
   DataContainer::Pointer container = getDataContainerArray()->createNonPrereqDataContainer<AbstractFilter>(this, getDataContainerName());
-  if(!container.get())
+  if(container.get() == nullptr)
   {
     setErrorCondition(-3);
     notifyErrorMessage(getHumanLabel(), "No container.", getErrorCondition());

--- a/ITKImageProcessingFilters/ITKImageWriter.cpp
+++ b/ITKImageProcessingFilters/ITKImageWriter.cpp
@@ -150,7 +150,7 @@ void ITKImageWriter::dataCheck()
   }
 
   ImageGeom::Pointer imageGeometry = getDataContainerArray()->getPrereqGeometryFromDataContainer<ImageGeom, AbstractFilter>(this, getImageArrayPath().getDataContainerName());
-  if(!imageGeometry.get())
+  if(imageGeometry.get() == nullptr)
   {
     setErrorCondition(-21003);
     notifyErrorMessage(getHumanLabel(), "No image geometry.", getErrorCondition());
@@ -187,11 +187,7 @@ bool ITKImageWriter::is2DFormat()
   QString Ext = itksys::SystemTools::LowerCase(itksys::SystemTools::GetFilenameExtension(getFileName().toStdString())).c_str();
   QStringList supported2DExtensions = ITKImageProcessingPlugin::getList2DSupportedFileExtensions();
   int index = supported2DExtensions.indexOf(QRegExp(".*" + Ext));
-  if(index != -1)
-  {
-    return true;
-  }
-  return false;
+  return index != -1;
 }
 
 // -----------------------------------------------------------------------------
@@ -457,7 +453,7 @@ void ITKImageWriter::saveImageData(DataContainerArray::Pointer dca, size_t slice
 AbstractFilter::Pointer ITKImageWriter::newFilterInstance(bool copyFilterParameters) const
 {
   ITKImageWriter::Pointer filter = ITKImageWriter::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKImportImageStack.cpp
+++ b/ITKImageProcessingFilters/ITKImportImageStack.cpp
@@ -155,7 +155,7 @@ void ITKImportImageStack::dataCheck()
   DataArrayPath tempPath;
   QString ss;
 
-  if(m_InputFileListInfo.InputPath.isEmpty() == true)
+  if(m_InputFileListInfo.InputPath.isEmpty())
   {
     ss = QObject::tr("The input directory must be set");
     setErrorCondition(-13);
@@ -181,7 +181,7 @@ void ITKImportImageStack::dataCheck()
 
   // Now generate all the file names the user is asking for and populate the table
   const QVector<QString> fileList = this->getFileList();
-  if(fileList.size() == 0)
+  if(fileList.empty())
   {
     ss.clear();
     QTextStream out(&ss);
@@ -436,7 +436,7 @@ void ITKImportImageStack::execute()
 AbstractFilter::Pointer ITKImportImageStack::newFilterInstance(bool copyFilterParameters) const
 {
   ITKImportImageStack::Pointer filter = ITKImportImageStack::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     filter->setFilterParameters(getFilterParameters());
     // We are going to hand copy all of the parameters because the other way of copying the parameters are going to

--- a/ITKImageProcessingFilters/ITKIntensityWindowingImage.cpp
+++ b/ITKImageProcessingFilters/ITKIntensityWindowingImage.cpp
@@ -135,7 +135,7 @@ void ITKIntensityWindowingImage::filterInternal()
 AbstractFilter::Pointer ITKIntensityWindowingImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKIntensityWindowingImage::Pointer filter = ITKIntensityWindowingImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKInvertIntensityImage.cpp
+++ b/ITKImageProcessingFilters/ITKInvertIntensityImage.cpp
@@ -123,7 +123,7 @@ void ITKInvertIntensityImage::filterInternal()
 AbstractFilter::Pointer ITKInvertIntensityImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKInvertIntensityImage::Pointer filter = ITKInvertIntensityImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKIsoContourDistanceImage.cpp
+++ b/ITKImageProcessingFilters/ITKIsoContourDistanceImage.cpp
@@ -127,7 +127,7 @@ void ITKIsoContourDistanceImage::filterInternal()
 AbstractFilter::Pointer ITKIsoContourDistanceImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKIsoContourDistanceImage::Pointer filter = ITKIsoContourDistanceImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKLabelContourImage.cpp
+++ b/ITKImageProcessingFilters/ITKLabelContourImage.cpp
@@ -127,7 +127,7 @@ void ITKLabelContourImage::filterInternal()
 AbstractFilter::Pointer ITKLabelContourImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKLabelContourImage::Pointer filter = ITKLabelContourImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKLaplacianRecursiveGaussianImage.cpp
+++ b/ITKImageProcessingFilters/ITKLaplacianRecursiveGaussianImage.cpp
@@ -127,7 +127,7 @@ void ITKLaplacianRecursiveGaussianImage::filterInternal()
 AbstractFilter::Pointer ITKLaplacianRecursiveGaussianImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKLaplacianRecursiveGaussianImage::Pointer filter = ITKLaplacianRecursiveGaussianImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKLaplacianSharpeningImage.cpp
+++ b/ITKImageProcessingFilters/ITKLaplacianSharpeningImage.cpp
@@ -123,7 +123,7 @@ void ITKLaplacianSharpeningImage::filterInternal()
 AbstractFilter::Pointer ITKLaplacianSharpeningImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKLaplacianSharpeningImage::Pointer filter = ITKLaplacianSharpeningImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKLog10Image.cpp
+++ b/ITKImageProcessingFilters/ITKLog10Image.cpp
@@ -22,10 +22,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-ITKLog10Image::ITKLog10Image()
-{
-
-}
+ITKLog10Image::ITKLog10Image() = default;
 
 // -----------------------------------------------------------------------------
 //
@@ -119,7 +116,7 @@ void ITKLog10Image::filterInternal()
 AbstractFilter::Pointer ITKLog10Image::newFilterInstance(bool copyFilterParameters) const
 {
   ITKLog10Image::Pointer filter = ITKLog10Image::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKLogImage.cpp
+++ b/ITKImageProcessingFilters/ITKLogImage.cpp
@@ -22,10 +22,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-ITKLogImage::ITKLogImage()
-{
-
-}
+ITKLogImage::ITKLogImage() = default;
 
 // -----------------------------------------------------------------------------
 //
@@ -119,7 +116,7 @@ void ITKLogImage::filterInternal()
 AbstractFilter::Pointer ITKLogImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKLogImage::Pointer filter = ITKLogImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKMaskImage.cpp
+++ b/ITKImageProcessingFilters/ITKMaskImage.cpp
@@ -233,7 +233,7 @@ void ITKMaskImage::filterInternal()
 AbstractFilter::Pointer ITKMaskImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKMaskImage::Pointer filter = ITKMaskImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKMaximumProjectionImage.cpp
+++ b/ITKImageProcessingFilters/ITKMaximumProjectionImage.cpp
@@ -124,7 +124,7 @@ void ITKMaximumProjectionImage::filterInternal()
 AbstractFilter::Pointer ITKMaximumProjectionImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKMaximumProjectionImage::Pointer filter = ITKMaximumProjectionImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKMeanProjectionImage.cpp
+++ b/ITKImageProcessingFilters/ITKMeanProjectionImage.cpp
@@ -124,7 +124,7 @@ void ITKMeanProjectionImage::filterInternal()
 AbstractFilter::Pointer ITKMeanProjectionImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKMeanProjectionImage::Pointer filter = ITKMeanProjectionImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKMedianImage.cpp
+++ b/ITKImageProcessingFilters/ITKMedianImage.cpp
@@ -124,7 +124,7 @@ void ITKMedianImage::filterInternal()
 AbstractFilter::Pointer ITKMedianImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKMedianImage::Pointer filter = ITKMedianImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKMedianProjectionImage.cpp
+++ b/ITKImageProcessingFilters/ITKMedianProjectionImage.cpp
@@ -124,7 +124,7 @@ void ITKMedianProjectionImage::filterInternal()
 AbstractFilter::Pointer ITKMedianProjectionImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKMedianProjectionImage::Pointer filter = ITKMedianProjectionImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKMinMaxCurvatureFlowImage.cpp
+++ b/ITKImageProcessingFilters/ITKMinMaxCurvatureFlowImage.cpp
@@ -132,7 +132,7 @@ void ITKMinMaxCurvatureFlowImage::filterInternal()
 AbstractFilter::Pointer ITKMinMaxCurvatureFlowImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKMinMaxCurvatureFlowImage::Pointer filter = ITKMinMaxCurvatureFlowImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKMinimumProjectionImage.cpp
+++ b/ITKImageProcessingFilters/ITKMinimumProjectionImage.cpp
@@ -124,7 +124,7 @@ void ITKMinimumProjectionImage::filterInternal()
 AbstractFilter::Pointer ITKMinimumProjectionImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKMinimumProjectionImage::Pointer filter = ITKMinimumProjectionImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKMorphologicalGradientImage.cpp
+++ b/ITKImageProcessingFilters/ITKMorphologicalGradientImage.cpp
@@ -170,7 +170,7 @@ void ITKMorphologicalGradientImage::filterInternal()
 AbstractFilter::Pointer ITKMorphologicalGradientImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKMorphologicalGradientImage::Pointer filter = ITKMorphologicalGradientImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKMorphologicalWatershedFromMarkersImage.cpp
+++ b/ITKImageProcessingFilters/ITKMorphologicalWatershedFromMarkersImage.cpp
@@ -203,7 +203,7 @@ void ITKMorphologicalWatershedFromMarkersImage::filterInternal()
 AbstractFilter::Pointer ITKMorphologicalWatershedFromMarkersImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKMorphologicalWatershedFromMarkersImage::Pointer filter = ITKMorphologicalWatershedFromMarkersImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKMorphologicalWatershedImage.cpp
+++ b/ITKImageProcessingFilters/ITKMorphologicalWatershedImage.cpp
@@ -131,7 +131,7 @@ void ITKMorphologicalWatershedImage::filterInternal()
 AbstractFilter::Pointer ITKMorphologicalWatershedImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKMorphologicalWatershedImage::Pointer filter = ITKMorphologicalWatershedImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKMultiScaleHessianBasedObjectnessImage.cpp
+++ b/ITKImageProcessingFilters/ITKMultiScaleHessianBasedObjectnessImage.cpp
@@ -169,7 +169,7 @@ void ITKMultiScaleHessianBasedObjectnessImage::filterInternal()
 AbstractFilter::Pointer ITKMultiScaleHessianBasedObjectnessImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKMultiScaleHessianBasedObjectnessImage::Pointer filter = ITKMultiScaleHessianBasedObjectnessImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKNormalizeImage.cpp
+++ b/ITKImageProcessingFilters/ITKNormalizeImage.cpp
@@ -22,10 +22,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-ITKNormalizeImage::ITKNormalizeImage()
-{
-
-}
+ITKNormalizeImage::ITKNormalizeImage() = default;
 
 // -----------------------------------------------------------------------------
 //
@@ -119,7 +116,7 @@ void ITKNormalizeImage::filterInternal()
 AbstractFilter::Pointer ITKNormalizeImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKNormalizeImage::Pointer filter = ITKNormalizeImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKNormalizeToConstantImage.cpp
+++ b/ITKImageProcessingFilters/ITKNormalizeToConstantImage.cpp
@@ -123,7 +123,7 @@ void ITKNormalizeToConstantImage::filterInternal()
 AbstractFilter::Pointer ITKNormalizeToConstantImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKNormalizeToConstantImage::Pointer filter = ITKNormalizeToConstantImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKNotImage.cpp
+++ b/ITKImageProcessingFilters/ITKNotImage.cpp
@@ -22,10 +22,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-ITKNotImage::ITKNotImage()
-{
-
-}
+ITKNotImage::ITKNotImage() = default;
 
 // -----------------------------------------------------------------------------
 //
@@ -119,7 +116,7 @@ void ITKNotImage::filterInternal()
 AbstractFilter::Pointer ITKNotImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKNotImage::Pointer filter = ITKNotImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKOpeningByReconstructionImage.cpp
+++ b/ITKImageProcessingFilters/ITKOpeningByReconstructionImage.cpp
@@ -178,7 +178,7 @@ void ITKOpeningByReconstructionImage::filterInternal()
 AbstractFilter::Pointer ITKOpeningByReconstructionImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKOpeningByReconstructionImage::Pointer filter = ITKOpeningByReconstructionImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKOtsuMultipleThresholdsImage.cpp
+++ b/ITKImageProcessingFilters/ITKOtsuMultipleThresholdsImage.cpp
@@ -142,7 +142,7 @@ void ITKOtsuMultipleThresholdsImage::filterInternal()
 AbstractFilter::Pointer ITKOtsuMultipleThresholdsImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKOtsuMultipleThresholdsImage::Pointer filter = ITKOtsuMultipleThresholdsImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKPatchBasedDenoisingImage.cpp
+++ b/ITKImageProcessingFilters/ITKPatchBasedDenoisingImage.cpp
@@ -169,7 +169,9 @@ template <typename InputPixelType, typename OutputPixelType, unsigned int Dimens
   filter->SetPatchRadius(static_cast<uint32_t>(m_PatchRadius));
   filter->SetNumberOfIterations(static_cast<uint32_t>(m_NumberOfIterations));
   if(this->m_NoiseSigma != 0.0)
+  {
     filter->SetNoiseSigma(this->m_NoiseSigma);
+  }
   filter->SetNoiseModelFidelityWeight(static_cast<double>(m_NoiseModelFidelityWeight));
   filter->SetAlwaysTreatComponentsAsEuclidean(static_cast<bool>(m_AlwaysTreatComponentsAsEuclidean));
   filter->SetKernelBandwidthEstimation(static_cast<bool>(m_KernelBandwidthEstimation));
@@ -204,7 +206,7 @@ void ITKPatchBasedDenoisingImage::filterInternal()
 AbstractFilter::Pointer ITKPatchBasedDenoisingImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKPatchBasedDenoisingImage::Pointer filter = ITKPatchBasedDenoisingImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKRGBToLuminanceImage.cpp
+++ b/ITKImageProcessingFilters/ITKRGBToLuminanceImage.cpp
@@ -21,9 +21,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-ITKRGBToLuminanceImage::ITKRGBToLuminanceImage()
-{
-}
+ITKRGBToLuminanceImage::ITKRGBToLuminanceImage() = default;
 
 // -----------------------------------------------------------------------------
 //
@@ -139,7 +137,7 @@ void ITKRGBToLuminanceImage::filterInternal()
 AbstractFilter::Pointer ITKRGBToLuminanceImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKRGBToLuminanceImage::Pointer filter = ITKRGBToLuminanceImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKRegionalMaximaImage.cpp
+++ b/ITKImageProcessingFilters/ITKRegionalMaximaImage.cpp
@@ -135,7 +135,7 @@ void ITKRegionalMaximaImage::filterInternal()
 AbstractFilter::Pointer ITKRegionalMaximaImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKRegionalMaximaImage::Pointer filter = ITKRegionalMaximaImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKRegionalMinimaImage.cpp
+++ b/ITKImageProcessingFilters/ITKRegionalMinimaImage.cpp
@@ -135,7 +135,7 @@ void ITKRegionalMinimaImage::filterInternal()
 AbstractFilter::Pointer ITKRegionalMinimaImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKRegionalMinimaImage::Pointer filter = ITKRegionalMinimaImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKRelabelComponentImage.cpp
+++ b/ITKImageProcessingFilters/ITKRelabelComponentImage.cpp
@@ -146,7 +146,7 @@ void ITKRelabelComponentImage::filterInternal()
 AbstractFilter::Pointer ITKRelabelComponentImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKRelabelComponentImage::Pointer filter = ITKRelabelComponentImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKRescaleIntensityImage.cpp
+++ b/ITKImageProcessingFilters/ITKRescaleIntensityImage.cpp
@@ -171,7 +171,7 @@ void ITKRescaleIntensityImage::filterInternal()
 AbstractFilter::Pointer ITKRescaleIntensityImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKRescaleIntensityImage::Pointer filter = ITKRescaleIntensityImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKSaltAndPepperNoiseImage.cpp
+++ b/ITKImageProcessingFilters/ITKSaltAndPepperNoiseImage.cpp
@@ -110,8 +110,10 @@ template <typename InputPixelType, typename OutputPixelType, unsigned int Dimens
   typedef itk::SaltAndPepperNoiseImageFilter<InputImageType, OutputImageType> FilterType;
   typename FilterType::Pointer filter = FilterType::New();
   filter->SetProbability(static_cast<double>(m_Probability));
-  if (m_Seed)
+  if(m_Seed)
+  {
     filter->SetSeed(m_Seed);
+  }
   this->ITKImageProcessingBase::filter<InputPixelType, OutputPixelType, Dimension, FilterType>(filter);
 
 }
@@ -130,7 +132,7 @@ void ITKSaltAndPepperNoiseImage::filterInternal()
 AbstractFilter::Pointer ITKSaltAndPepperNoiseImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKSaltAndPepperNoiseImage::Pointer filter = ITKSaltAndPepperNoiseImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKShiftScaleImage.cpp
+++ b/ITKImageProcessingFilters/ITKShiftScaleImage.cpp
@@ -127,7 +127,7 @@ void ITKShiftScaleImage::filterInternal()
 AbstractFilter::Pointer ITKShiftScaleImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKShiftScaleImage::Pointer filter = ITKShiftScaleImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKShotNoiseImage.cpp
+++ b/ITKImageProcessingFilters/ITKShotNoiseImage.cpp
@@ -109,8 +109,10 @@ template <typename InputPixelType, typename OutputPixelType, unsigned int Dimens
   typedef itk::ShotNoiseImageFilter<InputImageType, OutputImageType> FilterType;
   typename FilterType::Pointer filter = FilterType::New();
   filter->SetScale(static_cast<double>(m_Scale));
-  if (m_Seed)
+  if(m_Seed)
+  {
     filter->SetSeed(m_Seed);
+  }
   this->ITKImageProcessingBase::filter<InputPixelType, OutputPixelType, Dimension, FilterType>(filter);
 
 }
@@ -129,7 +131,7 @@ void ITKShotNoiseImage::filterInternal()
 AbstractFilter::Pointer ITKShotNoiseImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKShotNoiseImage::Pointer filter = ITKShotNoiseImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKSigmoidImage.cpp
+++ b/ITKImageProcessingFilters/ITKSigmoidImage.cpp
@@ -135,7 +135,7 @@ void ITKSigmoidImage::filterInternal()
 AbstractFilter::Pointer ITKSigmoidImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKSigmoidImage::Pointer filter = ITKSigmoidImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKSignedDanielssonDistanceMapImage.cpp
+++ b/ITKImageProcessingFilters/ITKSignedDanielssonDistanceMapImage.cpp
@@ -131,7 +131,7 @@ void ITKSignedDanielssonDistanceMapImage::filterInternal()
 AbstractFilter::Pointer ITKSignedDanielssonDistanceMapImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKSignedDanielssonDistanceMapImage::Pointer filter = ITKSignedDanielssonDistanceMapImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKSignedMaurerDistanceMapImage.cpp
+++ b/ITKImageProcessingFilters/ITKSignedMaurerDistanceMapImage.cpp
@@ -135,7 +135,7 @@ void ITKSignedMaurerDistanceMapImage::filterInternal()
 AbstractFilter::Pointer ITKSignedMaurerDistanceMapImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKSignedMaurerDistanceMapImage::Pointer filter = ITKSignedMaurerDistanceMapImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKSinImage.cpp
+++ b/ITKImageProcessingFilters/ITKSinImage.cpp
@@ -22,10 +22,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-ITKSinImage::ITKSinImage()
-{
-
-}
+ITKSinImage::ITKSinImage() = default;
 
 // -----------------------------------------------------------------------------
 //
@@ -119,7 +116,7 @@ void ITKSinImage::filterInternal()
 AbstractFilter::Pointer ITKSinImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKSinImage::Pointer filter = ITKSinImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKSmoothingRecursiveGaussianImage.cpp
+++ b/ITKImageProcessingFilters/ITKSmoothingRecursiveGaussianImage.cpp
@@ -130,7 +130,7 @@ void ITKSmoothingRecursiveGaussianImage::filterInternal()
 AbstractFilter::Pointer ITKSmoothingRecursiveGaussianImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKSmoothingRecursiveGaussianImage::Pointer filter = ITKSmoothingRecursiveGaussianImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKSpeckleNoiseImage.cpp
+++ b/ITKImageProcessingFilters/ITKSpeckleNoiseImage.cpp
@@ -109,7 +109,10 @@ template <typename InputPixelType, typename OutputPixelType, unsigned int Dimens
   typedef itk::SpeckleNoiseImageFilter<InputImageType, OutputImageType> FilterType;
   typename FilterType::Pointer filter = FilterType::New();
   filter->SetStandardDeviation(static_cast<double>(m_StandardDeviation));
-  if (m_Seed) filter->SetSeed(m_Seed);
+  if(m_Seed)
+  {
+    filter->SetSeed(m_Seed);
+  }
   this->ITKImageProcessingBase::filter<InputPixelType, OutputPixelType, Dimension, FilterType>(filter);
 
 }
@@ -128,7 +131,7 @@ void ITKSpeckleNoiseImage::filterInternal()
 AbstractFilter::Pointer ITKSpeckleNoiseImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKSpeckleNoiseImage::Pointer filter = ITKSpeckleNoiseImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKSqrtImage.cpp
+++ b/ITKImageProcessingFilters/ITKSqrtImage.cpp
@@ -22,10 +22,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-ITKSqrtImage::ITKSqrtImage()
-{
-
-}
+ITKSqrtImage::ITKSqrtImage() = default;
 
 // -----------------------------------------------------------------------------
 //
@@ -119,7 +116,7 @@ void ITKSqrtImage::filterInternal()
 AbstractFilter::Pointer ITKSqrtImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKSqrtImage::Pointer filter = ITKSqrtImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKSquareImage.cpp
+++ b/ITKImageProcessingFilters/ITKSquareImage.cpp
@@ -22,10 +22,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-ITKSquareImage::ITKSquareImage()
-{
-
-}
+ITKSquareImage::ITKSquareImage() = default;
 
 // -----------------------------------------------------------------------------
 //
@@ -119,7 +116,7 @@ void ITKSquareImage::filterInternal()
 AbstractFilter::Pointer ITKSquareImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKSquareImage::Pointer filter = ITKSquareImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKStandardDeviationProjectionImage.cpp
+++ b/ITKImageProcessingFilters/ITKStandardDeviationProjectionImage.cpp
@@ -124,7 +124,7 @@ void ITKStandardDeviationProjectionImage::filterInternal()
 AbstractFilter::Pointer ITKStandardDeviationProjectionImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKStandardDeviationProjectionImage::Pointer filter = ITKStandardDeviationProjectionImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKSumProjectionImage.cpp
+++ b/ITKImageProcessingFilters/ITKSumProjectionImage.cpp
@@ -124,7 +124,7 @@ void ITKSumProjectionImage::filterInternal()
 AbstractFilter::Pointer ITKSumProjectionImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKSumProjectionImage::Pointer filter = ITKSumProjectionImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKTanImage.cpp
+++ b/ITKImageProcessingFilters/ITKTanImage.cpp
@@ -22,10 +22,7 @@
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-ITKTanImage::ITKTanImage()
-{
-
-}
+ITKTanImage::ITKTanImage() = default;
 
 // -----------------------------------------------------------------------------
 //
@@ -119,7 +116,7 @@ void ITKTanImage::filterInternal()
 AbstractFilter::Pointer ITKTanImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKTanImage::Pointer filter = ITKTanImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKThresholdImage.cpp
+++ b/ITKImageProcessingFilters/ITKThresholdImage.cpp
@@ -131,7 +131,7 @@ void ITKThresholdImage::filterInternal()
 AbstractFilter::Pointer ITKThresholdImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKThresholdImage::Pointer filter = ITKThresholdImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKThresholdMaximumConnectedComponentsImage.cpp
+++ b/ITKImageProcessingFilters/ITKThresholdMaximumConnectedComponentsImage.cpp
@@ -138,7 +138,7 @@ void ITKThresholdMaximumConnectedComponentsImage::filterInternal()
 AbstractFilter::Pointer ITKThresholdMaximumConnectedComponentsImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKThresholdMaximumConnectedComponentsImage::Pointer filter = ITKThresholdMaximumConnectedComponentsImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKValuedRegionalMaximaImage.cpp
+++ b/ITKImageProcessingFilters/ITKValuedRegionalMaximaImage.cpp
@@ -128,7 +128,7 @@ void ITKValuedRegionalMaximaImage::filterInternal()
 AbstractFilter::Pointer ITKValuedRegionalMaximaImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKValuedRegionalMaximaImage::Pointer filter = ITKValuedRegionalMaximaImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKValuedRegionalMinimaImage.cpp
+++ b/ITKImageProcessingFilters/ITKValuedRegionalMinimaImage.cpp
@@ -128,7 +128,7 @@ void ITKValuedRegionalMinimaImage::filterInternal()
 AbstractFilter::Pointer ITKValuedRegionalMinimaImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKValuedRegionalMinimaImage::Pointer filter = ITKValuedRegionalMinimaImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKVectorConnectedComponentImage.cpp
+++ b/ITKImageProcessingFilters/ITKVectorConnectedComponentImage.cpp
@@ -146,7 +146,7 @@ void ITKVectorConnectedComponentImage::filterInternal()
 AbstractFilter::Pointer ITKVectorConnectedComponentImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKVectorConnectedComponentImage::Pointer filter = ITKVectorConnectedComponentImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKVectorRescaleIntensityImage.cpp
+++ b/ITKImageProcessingFilters/ITKVectorRescaleIntensityImage.cpp
@@ -166,7 +166,7 @@ void ITKVectorRescaleIntensityImage::filterInternal()
 AbstractFilter::Pointer ITKVectorRescaleIntensityImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKVectorRescaleIntensityImage::Pointer filter = ITKVectorRescaleIntensityImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKWhiteTopHatImage.cpp
+++ b/ITKImageProcessingFilters/ITKWhiteTopHatImage.cpp
@@ -174,7 +174,7 @@ void ITKWhiteTopHatImage::filterInternal()
 AbstractFilter::Pointer ITKWhiteTopHatImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKWhiteTopHatImage::Pointer filter = ITKWhiteTopHatImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKZeroCrossingImage.cpp
+++ b/ITKImageProcessingFilters/ITKZeroCrossingImage.cpp
@@ -129,7 +129,7 @@ void ITKZeroCrossingImage::filterInternal()
 AbstractFilter::Pointer ITKZeroCrossingImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKZeroCrossingImage::Pointer filter = ITKZeroCrossingImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ImportImageMontage.cpp
+++ b/ITKImageProcessingFilters/ImportImageMontage.cpp
@@ -97,7 +97,9 @@ void ImportImageMontage::initialize()
 {
   m_AttributeArrayNamesPtr = StringDataArray::NullPointer();
   if(m_InStream.isOpen())
+  {
     m_InStream.close();
+  }
   m_NumImages = 0;
   m_ArrayNames.clear();
   m_Coords.clear();
@@ -114,7 +116,7 @@ void ImportImageMontage::dataCheck()
 
   QString ss;
 
-  if(m_InputFileListInfo.InputPath.isEmpty() == true)
+  if(m_InputFileListInfo.InputPath.isEmpty())
   {
     ss = QObject::tr("The input directory must be set");
     setErrorCondition(-13);
@@ -160,7 +162,7 @@ void ImportImageMontage::dataCheck()
   QVector<QString> fileList = FilePathGenerator::GenerateFileList(m_InputFileListInfo.StartIndex, m_InputFileListInfo.EndIndex, m_InputFileListInfo.IncrementIndex, hasMissingFiles, orderAscending,
                                                                   m_InputFileListInfo.InputPath, m_InputFileListInfo.FilePrefix, m_InputFileListInfo.FileSuffix, m_InputFileListInfo.FileExtension,
                                                                   m_InputFileListInfo.PaddingDigits);
-  if(fileList.size() == 0)
+  if(fileList.empty())
   {
     QString ss = QObject::tr("No files have been selected for import. Have you set the input directory?");
     setErrorCondition(-11);
@@ -259,7 +261,7 @@ void ImportImageMontage::execute()
   QVector<QString> fileList = FilePathGenerator::GenerateFileList(m_InputFileListInfo.StartIndex, m_InputFileListInfo.EndIndex, m_InputFileListInfo.IncrementIndex, hasMissingFiles, orderAscending,
                                                                   m_InputFileListInfo.InputPath, m_InputFileListInfo.FilePrefix, m_InputFileListInfo.FileSuffix, m_InputFileListInfo.FileExtension,
                                                                   m_InputFileListInfo.PaddingDigits);
-  if(fileList.size() == 0)
+  if(fileList.empty())
   {
     QString ss = QObject::tr("No files have been selected for import. Have you set the input directory?");
     setErrorCondition(-11);
@@ -306,7 +308,7 @@ void ImportImageMontage::execute()
 AbstractFilter::Pointer ImportImageMontage::newFilterInstance(bool copyFilterParameters) const
 {
   ImportImageMontage::Pointer filter = ImportImageMontage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     filter->setFilterParameters(getFilterParameters());
     // We are going to hand copy all of the parameters because the other way of copying the parameters are going to

--- a/ITKImageProcessingFilters/ImportRegisteredImageMontage.cpp
+++ b/ITKImageProcessingFilters/ImportRegisteredImageMontage.cpp
@@ -152,7 +152,9 @@ void ImportRegisteredImageMontage::initialize()
 {
   m_AttributeArrayNamesPtr = StringDataArray::NullPointer();
   if(m_InStream.isOpen())
+  {
     m_InStream.close();
+  }
   m_NumImages = 0;
   m_ArrayNames.clear();
   m_Coords.clear();
@@ -170,7 +172,7 @@ void ImportRegisteredImageMontage::dataCheck()
   QString ss;
   int32_t err = 0;
 
-  if(m_InputFileListInfo.InputPath.isEmpty() == true)
+  if(m_InputFileListInfo.InputPath.isEmpty())
   {
     ss = QObject::tr("The input directory must be set");
     setErrorCondition(-13);
@@ -180,7 +182,7 @@ void ImportRegisteredImageMontage::dataCheck()
   }
 
   QFileInfo fi(m_RegistrationFile);
-  if(fi.exists() == false)
+  if(!fi.exists())
   {
     QString ss = QObject::tr("The registration file does not exist");
     setErrorCondition(-388);
@@ -188,7 +190,7 @@ void ImportRegisteredImageMontage::dataCheck()
     return;
   }
 
-  if(m_RegistrationFile.isEmpty() == true)
+  if(m_RegistrationFile.isEmpty())
   {
     QString ss = QObject::tr("The registration file must be set").arg(getHumanLabel());
     setErrorCondition(-1);
@@ -267,7 +269,7 @@ void ImportRegisteredImageMontage::dataCheck()
   QVector<QString> fileList = FilePathGenerator::GenerateFileList(m_InputFileListInfo.StartIndex, m_InputFileListInfo.EndIndex, m_InputFileListInfo.IncrementIndex, hasMissingFiles, orderAscending,
                                                                   m_InputFileListInfo.InputPath, m_InputFileListInfo.FilePrefix, m_InputFileListInfo.FileSuffix, m_InputFileListInfo.FileExtension,
                                                                   m_InputFileListInfo.PaddingDigits);
-  if(fileList.size() == 0)
+  if(fileList.empty())
   {
     QString ss = QObject::tr("No files have been selected for import. Have you set the input directory?");
     setErrorCondition(-11);
@@ -380,7 +382,7 @@ void ImportRegisteredImageMontage::execute()
   QVector<QString> fileList = FilePathGenerator::GenerateFileList(m_InputFileListInfo.StartIndex, m_InputFileListInfo.EndIndex, m_InputFileListInfo.IncrementIndex, hasMissingFiles, orderAscending,
                                                                   m_InputFileListInfo.InputPath, m_InputFileListInfo.FilePrefix, m_InputFileListInfo.FileSuffix, m_InputFileListInfo.FileExtension,
                                                                   m_InputFileListInfo.PaddingDigits);
-  if(fileList.size() == 0)
+  if(fileList.empty())
   {
     QString ss = QObject::tr("No files have been selected for import. Have you set the input directory?");
     setErrorCondition(-11);
@@ -436,7 +438,7 @@ void ImportRegisteredImageMontage::execute()
 AbstractFilter::Pointer ImportRegisteredImageMontage::newFilterInstance(bool copyFilterParameters) const
 {
   ImportRegisteredImageMontage::Pointer filter = ImportRegisteredImageMontage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     filter->setFilterParameters(getFilterParameters());
     // We are going to hand copy all of the parameters because the other way of copying the parameters are going to

--- a/ITKImageProcessingPlugin.cpp
+++ b/ITKImageProcessingPlugin.cpp
@@ -135,7 +135,7 @@ QString ITKImageProcessingPlugin::getListSupportedReadExtensions()
 {
   QStringList supportedExtensions;
   std::list<itk::LightObject::Pointer> allobjects = itk::ObjectFactoryBase::CreateAllInstance("itkImageIOBase");
-  if(allobjects.size() > 0)
+  if(!allobjects.empty())
   {
     for(std::list<itk::LightObject::Pointer>::iterator ii = allobjects.begin(); ii != allobjects.end(); ++ii)
     {
@@ -157,7 +157,7 @@ QString ITKImageProcessingPlugin::getListSupportedWriteExtensions()
 {
   QStringList supportedExtensions;
   std::list<itk::LightObject::Pointer> allobjects = itk::ObjectFactoryBase::CreateAllInstance("itkImageIOBase");
-  if(allobjects.size() > 0)
+  if(!allobjects.empty())
   {
     for(std::list<itk::LightObject::Pointer>::iterator ii = allobjects.begin(); ii != allobjects.end(); ++ii)
     {


### PR DESCRIPTION
clang-tidy was run with the following arguments:
-checks='-*,+readability-*,-readability-identifier-naming,modernize-use-equals-default'

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>