### PR TITLE
IGeometryGrid API Update, Python Fixes, MXA Removal

### DIFF
--- a/ITKImageProcessingFilters/ITKBinaryMinMaxCurvatureFlowImage.cpp
+++ b/ITKImageProcessingFilters/ITKBinaryMinMaxCurvatureFlowImage.cpp
@@ -136,7 +136,7 @@ void ITKBinaryMinMaxCurvatureFlowImage::filterInternal()
 AbstractFilter::Pointer ITKBinaryMinMaxCurvatureFlowImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKBinaryMinMaxCurvatureFlowImage::Pointer filter = ITKBinaryMinMaxCurvatureFlowImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKHistogramMatchingImage.cpp
+++ b/ITKImageProcessingFilters/ITKHistogramMatchingImage.cpp
@@ -88,7 +88,7 @@ size_t ITKHistogramMatchingImage::getImageDimension(const DataArrayPath& path)
   ImageGeom::Pointer imageGeometry = getDataContainerArray()->getPrereqGeometryFromDataContainer<ImageGeom, AbstractFilter>(this, path.getDataContainerName());
   if(imageGeometry.get() != nullptr)
   {
-    std::tie(tDims[0], tDims[1], tDims[2]) = imageGeometry->getDimensions();
+    tDims = imageGeometry->getDimensions().toContainer<QVector<size_t>>();
   }
   else
   {

--- a/ITKImageProcessingFilters/ITKImageWriter.cpp
+++ b/ITKImageProcessingFilters/ITKImageWriter.cpp
@@ -371,9 +371,8 @@ void ITKImageWriter::execute()
     return;
   }
 
-  size_t dims[3] = {0, 0, 0};
   ImageGeom::Pointer currentGeom = container->getGeometryAs<ImageGeom>();
-  std::tie(dims[0], dims[1], dims[2]) = currentGeom->getDimensions();
+  SizeVec3Type dims = currentGeom->getDimensions();
 
   DataContainerArray::Pointer dca = DataContainerArray::New();
   DataContainer::Pointer dc = DataContainer::New(container->getName());

--- a/ITKImageProcessingFilters/ITKImportImageStack.cpp
+++ b/ITKImageProcessingFilters/ITKImportImageStack.cpp
@@ -238,20 +238,18 @@ void ITKImportImageStack::dataCheck()
   // Extract the Geometry and update the geometry
   DataContainer::Pointer dc = dca->getDataContainer(getDataContainerName());
   ImageGeom::Pointer imageGeom = dc->getGeometryAs<ImageGeom>();
-  size_t x, y, z;
-  std::tie(x, y, z) = imageGeom->getDimensions();
-  z = fileList.size();
-  imageGeom->setDimensions(x, y, z);
-  imageGeom->setOrigin(m_Origin[0], m_Origin[1], m_Origin[2]);
-  imageGeom->setSpacing(m_Spacing[0], m_Spacing[1], m_Spacing[2]);
+  SizeVec3Type dims = imageGeom->getDimensions();
+  dims[2] = fileList.size();
+  imageGeom->setDimensions(dims);
+  imageGeom->setOrigin(m_Origin);
+  imageGeom->setSpacing(m_Spacing);
   m->setGeometry(imageGeom);
   dc->setGeometry(IGeometry::NullPointer());
 
   // Extract the Cell Attribute Matrix that was created and resize it for the number of Tuples that we have
   // and add it to the actual DataContainer that this filter created.
   AttributeMatrix::Pointer cellAttrMat = dc->getAttributeMatrix(getCellAttributeMatrixName());
-  QVector<size_t> tDims = {x, y, z};
-  cellAttrMat->resizeAttributeArrays(tDims);
+  cellAttrMat->resizeAttributeArrays(dims.toContainer<QVector<size_t>>());
   m->insertOrAssign(cellAttrMat);
   // The data array that was embedded in the Cell Attribute Matrix just got resized so we should not have to do
   // anything else at this point.
@@ -283,9 +281,8 @@ void readImageStack(ITKImportImageStack* filter, const QVector<QString>& fileLis
 
   DataContainer::Pointer dc = filter->getDataContainerArray()->getDataContainer(dcName);
   ImageGeom::Pointer imageGeom = dc->getGeometryAs<ImageGeom>();
-  size_t xDim, yDim, zDim;
-  std::tie(xDim, yDim, zDim) = imageGeom->getDimensions();
-  size_t tuplesPerSlice = xDim * yDim;
+  SizeVec3Type dims = imageGeom->getDimensions();
+  size_t tuplesPerSlice = dims[0] * dims[1];
   AttributeMatrix::Pointer cellAttrMatr = dc->getAttributeMatrix(attrMatName);
   using DataArrayType = DataArray<TPixel>;
   using DataArrayPointerType = typename DataArrayType::Pointer;
@@ -332,7 +329,7 @@ void readImageStack(ITKImportImageStack* filter, const QVector<QString>& fileLis
     }
 
     // Compute the Tuple Index we are at:
-    size_t tupleIndex = (slice * xDim * yDim);
+    size_t tupleIndex = (slice * dims[0] * dims[1]);
     // get the current Slice data...
     DataArrayPointerType tempData = dca->getDataContainer(dcName)->getAttributeMatrix(attrMatName)->getAttributeArrayAs<DataArrayType>(arrayName);
     // Copy that into the output array...

--- a/ITKImageProcessingFilters/ITKPCMTileRegistration.cpp
+++ b/ITKImageProcessingFilters/ITKPCMTileRegistration.cpp
@@ -388,8 +388,8 @@ void ITKPCMTileRegistration::createFijiDataStructure()
       continue;
     }
     ImageGeom::Pointer image = dcItem->getGeometryAs<ImageGeom>();
-    SIMPL::Tuple3SVec dimensions = image->getDimensions();
-    SIMPL::Tuple3FVec origin = image->getOrigin();
+    SizeVec3Type dimensions = image->getDimensions();
+    FloatVec3Type origin = image->getOrigin();
 
     // Extract row and column data from the data container name
     QString filename = ""; // Need to find this?

--- a/ITKImageProcessingFilters/ITKSobelEdgeDetectionImage.cpp
+++ b/ITKImageProcessingFilters/ITKSobelEdgeDetectionImage.cpp
@@ -116,7 +116,7 @@ void ITKSobelEdgeDetectionImage::filterInternal()
 AbstractFilter::Pointer ITKSobelEdgeDetectionImage::newFilterInstance(bool copyFilterParameters) const
 {
   ITKSobelEdgeDetectionImage::Pointer filter = ITKSobelEdgeDetectionImage::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/ITKImageProcessingFilters/ITKStitchMontage.cpp
+++ b/ITKImageProcessingFilters/ITKStitchMontage.cpp
@@ -492,8 +492,8 @@ void ITKStitchMontage::createFijiDataStructure()
       continue;
     }
     ImageGeom::Pointer image = dcItem->getGeometryAs<ImageGeom>();
-    SIMPL::Tuple3SVec dimensions = image->getDimensions();
-    SIMPL::Tuple3FVec origin = image->getOrigin();
+    SizeVec3Type dimensions = image->getDimensions();
+    FloatVec3Type origin = image->getOrigin();
 
     // Extract row and column data from the data container name
     QString filename = ""; // Need to find this?

--- a/ITKImageProcessingFilters/ImportVectorImageStack.cpp
+++ b/ITKImageProcessingFilters/ImportVectorImageStack.cpp
@@ -259,14 +259,13 @@ void ImportVectorImageStack::dataCheck()
       {
         // Get the geometry that was read from the ITKReadImage Filter
         ImageGeom::Pointer image = imageReaderDC->getGeometryAs<ImageGeom>();
-        size_t xDim = 0, yDim = 0, zDim = 0;
-        std::tie(xDim, yDim, zDim) = image->getDimensions();
+        SizeVec3Type dims = image->getDimensions();
         // Adjust the Z Dimension of the ImageGeometry and save it in our current Data Container.
-        zDim = static_cast<size_t>(totalIndex);
-        image->setDimensions(std::make_tuple(xDim, yDim, zDim));
+        dims[2] = static_cast<size_t>(totalIndex);
+        image->setDimensions(dims);
         m->setGeometry(image);
         // Set the number of tuples in the Cell AttributeMatrix
-        am->setTupleDimensions({xDim, yDim, zDim});
+        am->setTupleDimensions(dims.toContainer<QVector<size_t>>());
       }
       // Now figure out if the image was 8bit or 16 bit. The ONLY 2 types we are supporting
       // are 8 bit and 16 bit GrayScale images

--- a/Test/CMakeLists.txt
+++ b/Test/CMakeLists.txt
@@ -164,7 +164,7 @@ if(SIMPL_ENABLE_PYTHON)
 
     #------------------------------
     # Initialize the PYTHON_TEST_INPUT_DIR variable to point to the "Testing Directory"
-    file(TO_CMAKE_PATH "${${PLUGIN_NAME}Test_SOURCE_DIR}/Python" PYTHON_TEST_INPUT_DIR)
+    file(TO_NATIVE_PATH "${${PLUGIN_NAME}Test_SOURCE_DIR}/Python" PYTHON_TEST_INPUT_DIR)
     #------------------------------
     # These names should match the names "EXACTLY" (including capitalization).
     # NO Spaces in the names (which means no spaces in the variable names)
@@ -188,7 +188,7 @@ if(SIMPL_ENABLE_PYTHON)
     # Also setup a unit test for the base python unit test file that is generated as part
     # of the Pybind11 generated codes
     set(PYTHON_TEST_INPUT_DIR "${SIMPL_ANACONDA_OUTPUT_DIR}/UnitTest/${PLUGIN_NAME}")
-    set(SIMPL_PYTHON_TEST_DRIVER "${SIMPL_ANACONDA_OUTPUT_DIR}/UnitTest/${PLUGIN_NAME}/${PLUGIN_NAME}.sh")
+    set(SIMPL_PYTHON_TEST_DRIVER "${SIMPL_ANACONDA_OUTPUT_DIR}/UnitTest/${PLUGIN_NAME}/${PLUGIN_NAME}.${TEST_SCRIPT_FILE_EXT}")
     set(test "${PLUGIN_NAME}_UnitTest")
     configure_file(${SIMPL_PYTHON_TEST_SCRIPT}  "${SIMPL_PYTHON_TEST_DRIVER}" @ONLY)
     add_test(NAME PY_${PLUGIN_NAME}_UnitTest COMMAND "${SIMPL_PYTHON_TEST_DRIVER}" )

--- a/Test/CMakeLists.txt
+++ b/Test/CMakeLists.txt
@@ -153,3 +153,40 @@ if(${${PLUGIN_NAME}_ENABLE_SCIFIO})
 endif()
 
 add_dependencies(${PLUGIN_NAME}UnitTest ${PLUGIN_NAME}Gui)
+
+
+#------------------------------------------------------------------------------
+# If Python is enabled, then enable the Python unit tests for this plugin
+if(SIMPL_ENABLE_PYTHON)
+    get_property(SIMPL_ANACONDA_OUTPUT_DIR GLOBAL PROPERTY SIMPL_ANACONDA_OUTPUT_DIR)
+    get_property(SIMPL_PYTHON_TEST_SCRIPT GLOBAL PROPERTY SIMPL_PYTHON_TEST_SCRIPT)
+    get_property(PYTHON_SITE_PACKAGES_NAME GLOBAL PROPERTY PYTHON_SITE_PACKAGES_NAME)
+
+    #------------------------------
+    # Initialize the PYTHON_TEST_INPUT_DIR variable to point to the "Testing Directory"
+    file(TO_CMAKE_PATH "${${PLUGIN_NAME}Test_SOURCE_DIR}/Python" PYTHON_TEST_INPUT_DIR)
+    #------------------------------
+    # These names should match the names "EXACTLY" (including capitalization).
+    # NO Spaces in the names (which means no spaces in the variable names)
+    set(PLUGIN_PYTHON_TESTS
+
+    )
+
+    foreach(test ${PLUGIN_PYTHON_TESTS})
+        set(SIMPL_PYTHON_TEST_DRIVER "${SIMPL_ANACONDA_OUTPUT_DIR}/UnitTest/${PLUGIN_NAME}/${test}.sh")
+
+        configure_file(${SIMPL_PYTHON_TEST_SCRIPT}
+                        "${SIMPL_PYTHON_TEST_DRIVER}" @ONLY)
+
+        add_test(NAME ${PLUGIN_NAME}_${test} COMMAND "${SIMPL_PYTHON_TEST_DRIVER}" )
+    endforeach(test ${PLUGIN_PYTHON_TESTS})
+    #------------------------------
+    # Also setup a unit test for the base python unit test file that is generated as part
+    # of the Pybind11 generated codes
+    set(PYTHON_TEST_INPUT_DIR "${SIMPL_ANACONDA_OUTPUT_DIR}/UnitTest/${PLUGIN_NAME}")
+    set(SIMPL_PYTHON_TEST_DRIVER "${SIMPL_ANACONDA_OUTPUT_DIR}/UnitTest/${PLUGIN_NAME}/${PLUGIN_NAME}.sh")
+    set(test "${PLUGIN_NAME}_UnitTest")
+    configure_file(${SIMPL_PYTHON_TEST_SCRIPT}  "${SIMPL_PYTHON_TEST_DRIVER}" @ONLY)
+    add_test(NAME ${PLUGIN_NAME}_Python_UnitTest COMMAND "${SIMPL_PYTHON_TEST_DRIVER}" )
+endif()
+

--- a/Test/CMakeLists.txt
+++ b/Test/CMakeLists.txt
@@ -172,8 +172,12 @@ if(SIMPL_ENABLE_PYTHON)
 
     )
 
+    set(TEST_SCRIPT_FILE_EXT "sh")
+    if(WIN32)
+      set(TEST_SCRIPT_FILE_EXT "bat")
+    endif()
     foreach(test ${PLUGIN_PYTHON_TESTS})
-        set(SIMPL_PYTHON_TEST_DRIVER "${SIMPL_ANACONDA_OUTPUT_DIR}/UnitTest/${PLUGIN_NAME}/${test}.sh")
+        set(SIMPL_PYTHON_TEST_DRIVER "${SIMPL_ANACONDA_OUTPUT_DIR}/UnitTest/${PLUGIN_NAME}/${test}.${TEST_SCRIPT_FILE_EXT}")
 
         configure_file(${SIMPL_PYTHON_TEST_SCRIPT}
                         "${SIMPL_PYTHON_TEST_DRIVER}" @ONLY)

--- a/Test/CMakeLists.txt
+++ b/Test/CMakeLists.txt
@@ -178,7 +178,7 @@ if(SIMPL_ENABLE_PYTHON)
         configure_file(${SIMPL_PYTHON_TEST_SCRIPT}
                         "${SIMPL_PYTHON_TEST_DRIVER}" @ONLY)
 
-        add_test(NAME ${PLUGIN_NAME}_${test} COMMAND "${SIMPL_PYTHON_TEST_DRIVER}" )
+        add_test(NAME PY_${PLUGIN_NAME}_${test} COMMAND "${SIMPL_PYTHON_TEST_DRIVER}" )
     endforeach(test ${PLUGIN_PYTHON_TESTS})
     #------------------------------
     # Also setup a unit test for the base python unit test file that is generated as part
@@ -187,6 +187,6 @@ if(SIMPL_ENABLE_PYTHON)
     set(SIMPL_PYTHON_TEST_DRIVER "${SIMPL_ANACONDA_OUTPUT_DIR}/UnitTest/${PLUGIN_NAME}/${PLUGIN_NAME}.sh")
     set(test "${PLUGIN_NAME}_UnitTest")
     configure_file(${SIMPL_PYTHON_TEST_SCRIPT}  "${SIMPL_PYTHON_TEST_DRIVER}" @ONLY)
-    add_test(NAME ${PLUGIN_NAME}_Python_UnitTest COMMAND "${SIMPL_PYTHON_TEST_DRIVER}" )
+    add_test(NAME PY_${PLUGIN_NAME}_UnitTest COMMAND "${SIMPL_PYTHON_TEST_DRIVER}" )
 endif()
 

--- a/Test/ITKImageProcessingReaderTest.cpp
+++ b/Test/ITKImageProcessingReaderTest.cpp
@@ -307,12 +307,9 @@ void RemoveTestFiles()
     DREAM3D_REQUIRE_NE(imageGeometry.get(), 0);
 
     float tol = 1e-6;
-    FloatVec3Type resolution;
-    imageGeometry->getSpacing(resolution);
-    FloatVec3Type origin;
-    imageGeometry->getOrigin(origin);
-    size_t dimensions[3] = {0, 0, 0};
-    std::tie(dimensions[0], dimensions[1], dimensions[2]) = imageGeometry->getDimensions();
+    FloatVec3Type resolution = imageGeometry->getSpacing();
+    FloatVec3Type origin = imageGeometry->getOrigin();
+    SizeVec3Type dimensions = imageGeometry->getDimensions();
     for(size_t i = 0; i < Dimension; i++)
     {
       float imageSpacing = expectedImage->GetSpacing()[i];

--- a/Test/ITKImageProcessingWriterTest.cpp
+++ b/Test/ITKImageProcessingWriterTest.cpp
@@ -139,18 +139,13 @@ public:
   // -----------------------------------------------------------------------------
   bool CompareImageGeometries(const ImageGeom::Pointer& inputImageGeometry, const ImageGeom::Pointer& baselineImageGeometry)
   {
-    FloatVec3Type inputResolution;
-    FloatVec3Type baselineResolution;
-    inputImageGeometry->getSpacing(inputResolution);
-    baselineImageGeometry->getSpacing(baselineResolution);
-    FloatVec3Type inputOrigin;
-    FloatVec3Type baselineOrigin;
-    inputImageGeometry->getOrigin(inputOrigin);
-    baselineImageGeometry->getOrigin(baselineOrigin);
-    size_t inputDimensions[3];
-    size_t baselineDimensions[3];
-    std::tie(inputDimensions[0], inputDimensions[1], inputDimensions[2]) = inputImageGeometry->getDimensions();
-    std::tie(baselineDimensions[0], baselineDimensions[1], baselineDimensions[2]) = baselineImageGeometry->getDimensions();
+
+    FloatVec3Type inputResolution = inputImageGeometry->getSpacing();
+    FloatVec3Type baselineResolution = baselineImageGeometry->getSpacing();
+    FloatVec3Type inputOrigin = inputImageGeometry->getOrigin();
+    FloatVec3Type baselineOrigin = baselineImageGeometry->getOrigin();
+    SizeVec3Type inputDimensions = inputImageGeometry->getDimensions();
+    SizeVec3Type baselineDimensions = baselineImageGeometry->getDimensions();
     for(int i = 0; i < 3; i++)
     {
       // float tol = 1e-6;

--- a/Test/ITKImageProcessingWriterTest.cpp
+++ b/Test/ITKImageProcessingWriterTest.cpp
@@ -140,10 +140,10 @@ public:
   bool CompareImageGeometries(const ImageGeom::Pointer& inputImageGeometry, const ImageGeom::Pointer& baselineImageGeometry)
   {
 
-    FloatVec3Type inputResolution = inputImageGeometry->getSpacing();
-    FloatVec3Type baselineResolution = baselineImageGeometry->getSpacing();
-    FloatVec3Type inputOrigin = inputImageGeometry->getOrigin();
-    FloatVec3Type baselineOrigin = baselineImageGeometry->getOrigin();
+    //    FloatVec3Type inputResolution = inputImageGeometry->getSpacing();
+    //    FloatVec3Type baselineResolution = baselineImageGeometry->getSpacing();
+    //    FloatVec3Type inputOrigin = inputImageGeometry->getOrigin();
+    //    FloatVec3Type baselineOrigin = baselineImageGeometry->getOrigin();
     SizeVec3Type inputDimensions = inputImageGeometry->getDimensions();
     SizeVec3Type baselineDimensions = baselineImageGeometry->getDimensions();
     for(int i = 0; i < 3; i++)
@@ -155,6 +155,8 @@ public:
       // DREAM3D_COMPARE_FLOATS(&inputOrigin[i], &baselineOrigin[i], tol);
 
       DREAM3D_REQUIRE_EQUAL(inputDimensions[i], baselineDimensions[i]);
+      //      DREAM3D_REQUIRE_EQUAL(inputResolution[i], baselineResolution[i]);
+      //      DREAM3D_REQUIRE_EQUAL(inputOrigin[i], baselineOrigin[i]);
     }
     return true;
   }
@@ -480,17 +482,18 @@ public:
     namesGenerator->SetStartIndex(k_MinIndex);
     namesGenerator->SetEndIndex(k_MaxIndex); // There should be 96 slices: 90 + 3*2 (see CreateTestData)
     std::vector<std::string> listFileNames = namesGenerator->GetFileNames();
-    for(size_t ii = 0; ii < listFileNames.size(); ii++)
+    // for(size_t ii = 0; ii < listFileNames.size(); ii++)
+    for(const auto& fileName : listFileNames)
     {
       // Check that all files exist
-      QFileInfo check_file(listFileNames[ii].c_str());
+      QFileInfo check_file(fileName.c_str());
       if(!check_file.exists())
       {
-        std::cout << listFileNames[ii] << " Does not exist" << std::endl;
+        std::cout << fileName << " Does not exist" << std::endl;
       }
       DREAM3D_REQUIRE((check_file.exists() && check_file.isFile()));
       // Remove file
-      this->FilesToRemove << QString(listFileNames[ii].c_str());
+      this->FilesToRemove << QString(fileName.c_str());
     }
     return EXIT_SUCCESS;
   }

--- a/Test/ITKImportImageStackTest.cpp
+++ b/Test/ITKImportImageStackTest.cpp
@@ -281,10 +281,8 @@ AbstractFilter::Pointer GetFilterByName(const QString& filterName)
     ImageGeom::Pointer imageGeometry = std::dynamic_pointer_cast<ImageGeom>(geometry);
     DREAM3D_REQUIRE_NE(imageGeometry.get(), 0);
 
-    FloatVec3Type spacing;
-    imageGeometry->getSpacing(spacing);
-    FloatVec3Type origin;
-    imageGeometry->getOrigin(origin);
+    FloatVec3Type spacing = imageGeometry->getSpacing();
+    FloatVec3Type origin = imageGeometry->getOrigin();
 
     DREAM3D_COMPARE_FLOATS(&origin[0], &inputOrigin[0], 5);
     DREAM3D_COMPARE_FLOATS(&origin[1], &inputOrigin[1], 5);
@@ -294,12 +292,11 @@ AbstractFilter::Pointer GetFilterByName(const QString& filterName)
     DREAM3D_COMPARE_FLOATS(&spacing[1], &inputspacing[1], 5);
     DREAM3D_COMPARE_FLOATS(&spacing[2], &inputspacing[2], 5);
 
-    size_t dimensions[Dimension];
-    size_t expectedDimensions[Dimension];
+    SizeVec3Type dimensions = imageGeometry->getDimensions();
+    SizeVec3Type expectedDimensions;
     expectedDimensions[0] = 524;
     expectedDimensions[1] = 390;
     expectedDimensions[2] = 3;
-    std::tie(dimensions[0], dimensions[1], dimensions[2]) = imageGeometry->getDimensions();
     for(size_t i = 0; i < Dimension; ++i)
     {
       DREAM3D_REQUIRE_EQUAL(dimensions[i], expectedDimensions[i]);

--- a/Test/ITKTestBase.h
+++ b/Test/ITKTestBase.h
@@ -212,7 +212,11 @@ public:
     ImageGeom::Pointer imageGeometry = ImageGeom::New();
     imageGeometry = container->getGeometryAs<ImageGeom>();
     DREAM3D_REQUIRE_VALID_POINTER(imageGeometry.get());
-    std::tie(tDims[0], tDims[1], tDims[2]) = imageGeometry->getDimensions();
+    SizeVec3Type dims = imageGeometry->getDimensions();
+    tDims[0] = dims[0];
+    tDims[1] = dims[1];
+    tDims[2] = dims[2];
+
     type = ptr->getTypeAsString();
     cDims = ptr->getComponentDimensions();
     return 0;

--- a/Test/Python/Append_Z_Slice.py
+++ b/Test/Python/Append_Z_Slice.py
@@ -1,0 +1,61 @@
+# Based on Image Initial Visualization example
+# Tests the Append Z Slice filter
+# These are the simpl_py python modules
+
+from dream3d import simpl
+from dream3d import simpl_helpers as sc
+from dream3d import simpl_test_dirs as sd
+from dream3d import itkimageprocessing
+from dream3d import itkimageprocessingpy
+from dream3d import samplingpy
+
+
+def append_z_slice():
+    # Create Data Container Array
+    dca = simpl.DataContainerArray.New()
+
+    # Register the ImageIO Factories
+    image_writer = itkimageprocessing.ITKImageWriter.New()
+    image_writer.registerImageIOFactories()
+
+    # Import Image Stack [ITK]
+    file_list_info = simpl.FileListInfo(2, 0, 11, 174, 1, sd.GetDataDirectory() + "/Data/Image",
+                                        "slice_", "", "tif")
+    err = itkimageprocessingpy.itk_import_image_stack(dca, "RoboMet.3D Image Stack", "Optical Data",
+                                                      simpl.FloatVec3Type(0, 0, 0), simpl.FloatVec3Type(1, 1, 1),
+                                                      "", file_list_info, 164, "ImageData")
+    if err < 0:
+        print("ITK Import Image Stack ErrorCondition %d" % err)
+
+    # Append Image Geometry Z Slice #1
+    err = samplingpy.append_image_geometry_z_slice(dca,
+                                                   simpl.DataArrayPath("RoboMet.3D Image Stack",
+                                                                       "Optical Data", ""),
+                                                   simpl.DataArrayPath("RoboMet.3D Image Stack",
+                                                                       "Optical Data", ""), False)
+    if err < 0:
+        print("AppendImageGeometryZSlice #1 ErrorCondition: %d" % err)
+
+    # Append Image Geometry Z Slice #2
+    err = samplingpy.append_image_geometry_z_slice(dca,
+                                                   simpl.DataArrayPath("RoboMet.3D Image Stack",
+                                                                       "Optical Data", ""),
+                                                   simpl.DataArrayPath("RoboMet.3D Image Stack",
+                                                                       "Optical Data", ""), False)
+    if err < 0:
+        print("AppendImageGeometryZSlice #2 ErrorCondition: %d" % err)
+
+    # Write to DREAM3D file
+    err = sc.WriteDREAM3DFile(sd.GetBuildDirectory() +
+                              "/Data/Output/CoreFilterTests/" + 
+                              "AppendImageGeometryZSlice.dream3d",
+                              dca)
+    if err < 0:
+        print("WriteDREAM3DFile ErrorCondition: %d" % err)
+
+
+"""
+Main entry point for python script
+"""
+if __name__ == "__main__":
+    append_z_slice()

--- a/Utilities/SimpleITKJSONDream3DFilterCreationTemplates/ImageFilterTemplate.cpp
+++ b/Utilities/SimpleITKJSONDream3DFilterCreationTemplates/ImageFilterTemplate.cpp
@@ -117,7 +117,7 @@ ${FilterInternal}
 AbstractFilter::Pointer ${FilterName}::newFilterInstance(bool copyFilterParameters) const
 {
   ${FilterName}::Pointer filter = ${FilterName}::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }

--- a/Utilities/SimpleITKJSONDream3DFilterCreationTemplates/KernelImageFilterTemplate.cpp
+++ b/Utilities/SimpleITKJSONDream3DFilterCreationTemplates/KernelImageFilterTemplate.cpp
@@ -161,7 +161,7 @@ ${FilterInternal}
 AbstractFilter::Pointer ${FilterName}::newFilterInstance(bool copyFilterParameters) const
 {
   ${FilterName}::Pointer filter = ${FilterName}::New();
-  if(true == copyFilterParameters)
+  if(copyFilterParameters)
   {
     copyFilterParameterInstanceVariables(filter.get());
   }


### PR DESCRIPTION
The API is changed to use a FloatVec3Type or SizeVec3Type (both alias for SIMPLArray<T, N>) so that
the API is consistent among the various classes and easy to use within SIMPL/DREAM.3D and its plugins.
The use of the std::tuple based return types is deprecated and removed.

The Python script files were completely reorganized to put the scripts with their plugins. Most of
the scripts were tested on a macOS machine and added to the ctest suite of unit tests. For each script
a bash script is created that drives the test. The Python tests are dependant on an Anaconda3 installation
being used. A few of the Python tests are still failing but those will be fixed eventually

The source code was searched for the old and deprecated MXA strings and classes and the old code was
either removed or renamed to SIMPL.

Signed-off-by: Michael Jackson mike.jackson@bluequartz.net