### PR TITLE
Topic/import montage fixes

### DIFF
--- a/ITKImageProcessingFilters/ITKImportMontage.cpp
+++ b/ITKImageProcessingFilters/ITKImportMontage.cpp
@@ -1,0 +1,370 @@
+/* ============================================================================
+* Copyright (c) 2009-2016 BlueQuartz Software, LLC
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+*
+* Redistributions in binary form must reproduce the above copyright notice, this
+* list of conditions and the following disclaimer in the documentation and/or
+* other materials provided with the distribution.
+*
+* Neither the name of BlueQuartz Software, the US Air Force, nor the names of its
+* contributors may be used to endorse or promote products derived from this software
+* without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The code contained herein was partially funded by the followig contracts:
+*    United States Air Force Prime Contract FA8650-07-D-5800
+*    United States Air Force Prime Contract FA8650-10-D-5210
+*    United States Prime Contract Navy N00173-07-C-2068
+*
+* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#include "ITKImportMontage.h"
+
+#include <QtCore/QFileInfo>
+
+#include "ITKImageProcessing/ITKImageProcessingConstants.h"
+#include "ITKImageProcessing/ITKImageProcessingVersion.h"
+
+/* ############## Start Private Implementation ############################### */
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+class ITKImportMontagePrivate
+{
+  Q_DISABLE_COPY(ITKImportMontagePrivate)
+  Q_DECLARE_PUBLIC(ITKImportMontage)
+  ITKImportMontage* const q_ptr;
+  ITKImportMontagePrivate(ITKImportMontage* ptr);
+  ITKImportMontage::MontageCacheVector m_MontageCacheVector;
+  FloatVec3Type montageMinCoord;
+  FloatVec3Type montageSpacing;
+};
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+ITKImportMontagePrivate::ITKImportMontagePrivate(ITKImportMontage* ptr)
+: q_ptr(ptr)
+{
+  montageMinCoord = {std::numeric_limits<float>::max(), std::numeric_limits<float>::max(), std::numeric_limits<float>::max()};
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+ITKImportMontage::ITKImportMontage()
+: m_DataContainerPrefix(SIMPL::Defaults::ImageDataContainerName + "_")
+, m_CellAttributeMatrixName(SIMPL::Defaults::CellAttributeMatrixName)
+, m_AttributeArrayName("ImageTile")
+, d_ptr(new ITKImportMontagePrivate(this))
+, m_RowCount(0)
+, m_ColumnCount(0)
+, m_ChangeOrigin(false)
+, m_ChangeSpacing(false)
+{
+
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+ITKImportMontage::~ITKImportMontage() = default;
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+SIMPL_PIMPL_PROPERTY_DEF(ITKImportMontage, ITKImportMontage::MontageCacheVector, MontageCacheVector)
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void ITKImportMontage::appendToCache(const ITKImageReader::Pointer &reader, const QString &filePath, QPointF coords, int row, int col, FloatVec3Type spacing)
+{
+  Q_D(ITKImportMontage);
+
+  ITKMontageCache cache;
+  cache.imageReader = reader;
+  cache.filePath = filePath;
+  cache.coords = coords;
+  cache.row = row;
+  cache.col = col;
+
+  d->montageMinCoord[0] = std::min<float>(coords.x(), d->montageMinCoord[0]);
+  d->montageMinCoord[1] = std::min<float>(coords.y(), d->montageMinCoord[1]);
+  d->montageMinCoord[2] = 1.0f;
+
+  d->montageSpacing = spacing;
+
+  d->m_MontageCacheVector.push_back(cache);
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void ITKImportMontage::initialize()
+{
+  clearErrorCode();
+  clearWarningCode();
+  setCancel(false);
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void ITKImportMontage::setupFilterParameters()
+{
+  FilterParameterVectorType parameters;
+
+  setFilterParameters(parameters);
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void ITKImportMontage::dataCheck()
+{
+  clearErrorCode();
+  clearWarningCode();
+  initialize();
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void ITKImportMontage::readImageFile(const QString &filePath, QPointF coords, int row, int col)
+{
+  QFileInfo fi(filePath);
+  QString rowColIdString = tr("r%1c%2").arg(row).arg(col);
+
+  QString dcName = tr("%1_%2").arg(getDataContainerPrefix()).arg(rowColIdString);
+
+  ITKImageReader::Pointer reader = ITKImageReader::New();
+  reader->setFileName(fi.filePath());
+  reader->setDataContainerName(DataArrayPath(dcName, "", ""));
+  reader->setCellAttributeMatrixName(getCellAttributeMatrixName());
+  reader->setImageDataArrayName(getAttributeArrayName());
+
+  if (getInPreflight())
+  {
+    reader->preflight();
+  }
+  else
+  {
+    reader->execute();
+  }
+
+  DataContainerArray::Pointer filterDca = reader->getDataContainerArray();
+  DataContainerArray::Container dcs = filterDca->getDataContainers();
+  for (DataContainer::Pointer dc : dcs)
+  {
+    getDataContainerArray()->addOrReplaceDataContainer(dc);
+  }
+
+  DataContainer::Pointer m = getDataContainerArray()->getPrereqDataContainer<AbstractFilter>(this, dcName);
+  if(getErrorCode() < 0)
+  {
+    return;
+  }
+
+  ImageGeom::Pointer geom = m->getGeometryAs<ImageGeom>();
+  geom->setOrigin(coords.x(), coords.y(), 1.0f);
+
+  FloatVec3Type spacing;
+  geom->getSpacing(spacing);
+
+  appendToCache(reader, filePath, coords, row, col, spacing);
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void ITKImportMontage::readImagesFromCache()
+{
+  MontageCacheVector montageCacheVector = getMontageCacheVector();
+  for (int i = 0; i < montageCacheVector.size(); i++)
+  {
+    ITKMontageCache montageCache = montageCacheVector[i];
+
+    QString rowColIdString = tr("r%1c%2").arg(montageCache.row).arg(montageCache.col);
+    QString dcName = tr("%1_%2").arg(getDataContainerPrefix()).arg(rowColIdString);
+
+    ITKImageReader::Pointer reader = montageCache.imageReader;
+    reader->setDataContainerName(DataArrayPath(dcName, "", ""));
+    reader->setCellAttributeMatrixName(getCellAttributeMatrixName());
+    reader->setImageDataArrayName(getAttributeArrayName());
+    reader->setDataContainerArray(DataContainerArray::New());
+    if (getInPreflight())
+    {
+      reader->preflight();
+    }
+    else
+    {
+      reader->execute();
+    }
+
+    DataContainerArray::Pointer filterDca = reader->getDataContainerArray();
+    DataContainerArray::Container dcs = filterDca->getDataContainers();
+    for (DataContainer::Pointer dc : dcs)
+    {
+      getDataContainerArray()->addOrReplaceDataContainer(dc);
+
+      QPointF coords = montageCache.coords;
+
+      ImageGeom::Pointer geom = dc->getGeometryAs<ImageGeom>();
+
+      geom->setOrigin(coords.x(), coords.y(), 1.0f);
+    }
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void ITKImportMontage::adjustOriginAndSpacing()
+{
+  Q_D(ITKImportMontage);
+
+  FloatVec3Type overrideOrigin = d->montageMinCoord;
+  FloatVec3Type overrideSpacing = d->montageSpacing;
+
+  if(getChangeOrigin())
+  {
+    overrideOrigin = {m_Origin[0], m_Origin[1], m_Origin[2]};
+  }
+  if(getChangeSpacing())
+  {
+    overrideSpacing = {m_Spacing[0], m_Spacing[1], m_Spacing[2]};
+  }
+
+  MontageCacheVector montageCacheVector = getMontageCacheVector();
+  for (int i = 0; i < montageCacheVector.size(); i++)
+  {
+    ITKMontageCache montageCache = montageCacheVector[i];
+    QString rowColIdString = tr("r%1c%2").arg(montageCache.row).arg(montageCache.col);
+    QString dcName = tr("%1_%2").arg(getDataContainerPrefix()).arg(rowColIdString);
+
+    DataContainer::Pointer dc = getDataContainerArray()->getDataContainer(dcName);
+    ImageGeom::Pointer imageGeom = dc->getGeometryAs<ImageGeom>();
+
+    FloatVec3Type currentOrigin;
+    imageGeom->getOrigin(currentOrigin);
+
+    FloatVec3Type currentSpacing;
+    imageGeom->getSpacing(currentSpacing);
+
+    for(size_t i = 0; i < 3; i++)
+    {
+      float delta = currentOrigin[i] - d->montageMinCoord[i];
+      // Convert to Pixel Coords
+      delta = delta / currentSpacing[i];
+      // Convert to the override origin
+      delta = delta * overrideSpacing[i];
+      currentOrigin[i] = overrideOrigin[i] + delta;
+    }
+    imageGeom->setOrigin(currentOrigin.data());
+    imageGeom->setSpacing(overrideSpacing.data());
+  }
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void ITKImportMontage::preflight()
+{
+  setInPreflight(true);
+  emit preflightAboutToExecute();
+  emit updateFilterParameters(this);
+  dataCheck();
+  emit preflightExecuted();
+  setInPreflight(false);
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void ITKImportMontage::execute()
+{
+  clearErrorCode();
+  clearWarningCode();
+  dataCheck();
+  if(getErrorCode() < 0)
+  {
+    return;
+  }
+
+  /* Let the GUI know we are done with this filter */
+  notifyStatusMessage("Complete");
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+const QString ITKImportMontage::getCompiledLibraryName() const
+{
+  return ITKImageProcessingConstants::ITKImageProcessingBaseName;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+const QString ITKImportMontage::getBrandingString() const
+{
+  return "ITKImageProcessing";
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+const QString ITKImportMontage::getFilterVersion() const
+{
+  QString version;
+  QTextStream vStream(&version);
+  vStream << ITKImageProcessing::Version::Major() << "." << ITKImageProcessing::Version::Minor() << "." << ITKImageProcessing::Version::Patch();
+  return version;
+}
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+const QString ITKImportMontage::getGroupName() const
+{
+  return SIMPL::FilterGroups::IOFilters;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+const QUuid ITKImportMontage::getUuid()
+{
+  return QUuid("{5808733b-cc12-5486-ac5f-ff0107807e74}");
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+const QString ITKImportMontage::getSubGroupName() const
+{
+  return SIMPL::FilterSubGroups::InputFilters;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+const QString ITKImportMontage::getHumanLabel() const
+{
+  return "Import Montage";
+}

--- a/ITKImageProcessingFilters/ITKImportMontage.cpp
+++ b/ITKImageProcessingFilters/ITKImportMontage.cpp
@@ -184,8 +184,7 @@ void ITKImportMontage::readImageFile(const QString &filePath, QPointF coords, in
   ImageGeom::Pointer geom = m->getGeometryAs<ImageGeom>();
   geom->setOrigin(coords.x(), coords.y(), 1.0f);
 
-  FloatVec3Type spacing;
-  geom->getSpacing(spacing);
+  FloatVec3Type spacing = geom->getSpacing();
 
   appendToCache(reader, filePath, coords, row, col, spacing);
 }
@@ -261,11 +260,9 @@ void ITKImportMontage::adjustOriginAndSpacing()
     DataContainer::Pointer dc = getDataContainerArray()->getDataContainer(dcName);
     ImageGeom::Pointer imageGeom = dc->getGeometryAs<ImageGeom>();
 
-    FloatVec3Type currentOrigin;
-    imageGeom->getOrigin(currentOrigin);
+    FloatVec3Type currentOrigin = imageGeom->getOrigin();
 
-    FloatVec3Type currentSpacing;
-    imageGeom->getSpacing(currentSpacing);
+    FloatVec3Type currentSpacing = imageGeom->getSpacing();
 
     for(size_t i = 0; i < 3; i++)
     {

--- a/ITKImageProcessingFilters/ITKImportRoboMetMontage.h
+++ b/ITKImageProcessingFilters/ITKImportRoboMetMontage.h
@@ -6,20 +6,7 @@
 
 #include <QtCore/QFile>
 
-#include "SIMPLib/Common/SIMPLibSetGetMacros.h"
-#include "SIMPLib/DataArrays/StringDataArray.h"
-#include "SIMPLib/FilterParameters/FileListInfoFilterParameter.h"
-#include "SIMPLib/FilterParameters/FloatVec3FilterParameter.h"
-#include "SIMPLib/Filtering/AbstractFilter.h"
-#include "SIMPLib/SIMPLib.h"
-
-#include "SIMPLib/ITK/itkImageReaderHelper.h"
-
-#include <itkImageFileReader.h>
-
-#include "ITKImageProcessing/ITKImageProcessingFilters/ITKImageReader.h"
-
-#include "ITKImageProcessing/ITKImageProcessingDLLExport.h"
+#include "ITKImageProcessing/ITKImageProcessingFilters/ITKImportMontage.h"
 
  // our PIMPL private class
 class ITKImportRoboMetMontagePrivate;
@@ -27,21 +14,15 @@ class ITKImportRoboMetMontagePrivate;
 /**
  * @brief The ITKImportRoboMetMontage class. See [Filter documentation](@ref ITKImportRoboMetMontage) for details.
  */
-class ITKImageProcessing_EXPORT ITKImportRoboMetMontage : public AbstractFilter
+class ITKImageProcessing_EXPORT ITKImportRoboMetMontage : public ITKImportMontage
 {
   Q_OBJECT
   
   PYB11_CREATE_BINDINGS(ITKImportRoboMetMontage SUPERCLASS AbstractFilter)
-  PYB11_PROPERTY(QString DataContainerName READ getDataContainerName WRITE setDataContainerName)
-  PYB11_PROPERTY(QString CellAttributeMatrixName READ getCellAttributeMatrixName WRITE setCellAttributeMatrixName)
   PYB11_PROPERTY(int SliceNumber READ getSliceNumber WRITE setSliceNumber)
   PYB11_PROPERTY(QString MetaDataAttributeMatrixName READ getMetaDataAttributeMatrixName WRITE setMetaDataAttributeMatrixName)
-  PYB11_PROPERTY(FloatVec3Type Origin READ getOrigin WRITE setOrigin)
-  PYB11_PROPERTY(FloatVec3Type Spacing READ getSpacing WRITE setSpacing)
   PYB11_PROPERTY(QString RegistrationFile READ getRegistrationFile WRITE setRegistrationFile)
-  PYB11_PROPERTY(QString AttributeArrayName READ getAttributeArrayName WRITE setAttributeArrayName)
   PYB11_PROPERTY(QString ImageFilePrefix READ getImageFilePrefix WRITE setImageFilePrefix)
-  PYB11_PROPERTY(QString ImageFileSuffix READ getImageFileSuffix WRITE setImageFileSuffix)
   PYB11_PROPERTY(QString ImageFileExtension READ getImageFileExtension WRITE setImageFileExtension)
    
   Q_DECLARE_PRIVATE(ITKImportRoboMetMontage)
@@ -58,35 +39,17 @@ public:
 
   SIMPL_INSTANCE_STRING_PROPERTY(ErrorMessage)
 
-  SIMPL_FILTER_PARAMETER(QString, DataContainerName)
-  Q_PROPERTY(QString DataContainerName READ getDataContainerName WRITE setDataContainerName)
-
-  SIMPL_FILTER_PARAMETER(QString, CellAttributeMatrixName)
-  Q_PROPERTY(QString CellAttributeMatrixName READ getCellAttributeMatrixName WRITE setCellAttributeMatrixName)
-
   SIMPL_FILTER_PARAMETER(int, SliceNumber)
   Q_PROPERTY(int SliceNumber READ getSliceNumber WRITE setSliceNumber)
 
   SIMPL_FILTER_PARAMETER(QString, MetaDataAttributeMatrixName)
   Q_PROPERTY(QString MetaDataAttributeMatrixName READ getMetaDataAttributeMatrixName WRITE setMetaDataAttributeMatrixName)
 
-  SIMPL_FILTER_PARAMETER(FloatVec3Type, Origin)
-  Q_PROPERTY(FloatVec3Type Origin READ getOrigin WRITE setOrigin)
-
-  SIMPL_FILTER_PARAMETER(FloatVec3Type, Spacing)
-  Q_PROPERTY(FloatVec3Type Spacing READ getSpacing WRITE setSpacing)
-
   SIMPL_FILTER_PARAMETER(QString, RegistrationFile)
   Q_PROPERTY(QString RegistrationFile READ getRegistrationFile WRITE setRegistrationFile)
 
-  SIMPL_FILTER_PARAMETER(QString, AttributeArrayName)
-  Q_PROPERTY(QString AttributeArrayName READ getAttributeArrayName WRITE setAttributeArrayName)
-
   SIMPL_FILTER_PARAMETER(QString, ImageFilePrefix)
   Q_PROPERTY(QString ImageFilePrefix READ getImageFilePrefix WRITE setImageFilePrefix)
-
-  SIMPL_FILTER_PARAMETER(QString, ImageFileSuffix)
-  Q_PROPERTY(QString ImageFileSuffix READ getImageFileSuffix WRITE setImageFileSuffix)
 
   SIMPL_FILTER_PARAMETER(QString, ImageFileExtension)
   Q_PROPERTY(QString ImageFileExtension READ getImageFileExtension WRITE setImageFileExtension)
@@ -95,19 +58,6 @@ public:
 
   SIMPL_PIMPL_PROPERTY_DECL(QString, RoboMetConfigFilePathCache)
   SIMPL_PIMPL_PROPERTY_DECL(QDateTime, LastRead)
-  SIMPL_PIMPL_GET_PROPERTY_DECL(ReaderMap, ReaderCache)
-
-  /**
-   * @brief setReaderCacheValue
-   * @param filePath
-   * @param reader
-   */
-  void setReaderCacheValue(const QString &filePath, const ITKImageReader::Pointer &reader);
-
-  /**
-   * @brief clearReaderCache
-   */
-  void clearReaderCache();
 
   /**
    * @brief getCompiledLibraryName Reimplemented from @see AbstractFilter class
@@ -197,10 +147,9 @@ protected:
 
   /**
    * @brief parseFijiConfigFile Parses the Fiji file with the configuration coordinates
-   * @param reader QFile to read
    * @return Integer error value
    */
-  int32_t parseRoboMetConfigFile(const QString &filePath);
+  int32_t parseRoboMetConfigFile();
 
   /**
    * @brief parseRobometConfigFile Parses the Robomet file with the configuration coordinates
@@ -230,24 +179,13 @@ private:
   int32_t m_NumImages;
   std::vector<QString> m_RegisteredFilePaths;
   QMap<QString, QPointF> m_CoordsMap;
-  QMap<QString, QString> m_RowColIdMap;
-
-  /**
-   * @brief readDataFile
-   * @param filePath
-   */
-  void readImageFile(const QString &filePath);
+  std::vector<int> m_Rows;
+  std::vector<int> m_Columns;
 
   /**
    * @brief clearParsingCache
    */
   void clearParsingCache();
-
-  /**
-   * @brief Include the declarations of the ITKImageReader helper functions that are common
-   * to a few different filters across different plugins.
-   */
-  ITK_IMAGE_READER_HELPER_ImageDataArrayName() ITK_IMAGE_READER_HELPER_DECL()
 
 public :
   ITKImportRoboMetMontage(const ITKImportRoboMetMontage&) = delete; // Copy Constructor Not Implemented

--- a/ITKImageProcessingFilters/ITKStitchMontage.h
+++ b/ITKImageProcessingFilters/ITKStitchMontage.h
@@ -66,7 +66,6 @@ class ITKImageProcessing_EXPORT ITKStitchMontage : public AbstractFilter
   PYB11_PROPERTY(QStringList, ImageDataContainers READ getImageDataContainers WRITE setImageDataContainers)
   PYB11_PROPERTY(QString CommonAttributeMatrixName READ getCommonAttributeMatrixName WRITE setCommonAttributeMatrixName)
   PYB11_PROPERTY(QString CommonDataArrayName READ getCommonDataArrayName WRITE setCommonDataArrayName)
-  PYB11_PROPERTY(float TileOverlap READ getTileOverlap WRITE setTileOverlap)
 public:
   SIMPL_SHARED_POINTERS(ITKStitchMontage)
   SIMPL_FILTER_NEW_MACRO(ITKStitchMontage)
@@ -97,12 +96,6 @@ public:
 
   SIMPL_FILTER_PARAMETER(QString, MontageDataArrayName)
   Q_PROPERTY(QString MontageDataArrayName READ getMontageDataArrayName WRITE setMontageDataArrayName)
-
-  SIMPL_FILTER_PARAMETER(bool, ManualTileOverlap)
-  Q_PROPERTY(bool ManualTileOverlap READ getManualTileOverlap WRITE setManualTileOverlap)
-
-  SIMPL_FILTER_PARAMETER(float, TileOverlap)
-  Q_PROPERTY(float TileOverlap READ getTileOverlap WRITE setTileOverlap)
 
   /**
    * @brief getCompiledLibraryName Reimplemented from @see AbstractFilter class

--- a/ITKImageProcessingFilters/SourceList.cmake
+++ b/ITKImageProcessingFilters/SourceList.cmake
@@ -163,6 +163,7 @@ endforeach()
 # This is the list of Private Filters. These filters are available from other filters but the user will not
 # be able to use them from the DREAM3D user interface.
 set(_PrivateFilters
+  ITKImportMontage
   ITKImageProcessingBase
   ImportImageMontage
 )


### PR DESCRIPTION
* Creating a superclass for ITK montage import filters that has common code in it.
* Adding code that overrides the origin and spacing correctly for each tile that is imported.
* Cleaning up include statements and pybind11 declarations that are no longer needed.
* Removing tileOverlap parameter in ITKStitchMontage because the tiles should already be in the right place before this stitching filter is executed.