### PR TITLE
Adding Pixel Coordinates filter parameter to the import montage filters and updating origin adjustment algorithm in ITKImportMontage superclass.

### DIFF
--- a/ITKImageProcessingFilters/ITKImportFijiMontage.cpp
+++ b/ITKImageProcessingFilters/ITKImportFijiMontage.cpp
@@ -39,6 +39,7 @@
 #include "SIMPLib/FilterParameters/DoubleFilterParameter.h"
 #include "SIMPLib/FilterParameters/FloatVec3FilterParameter.h"
 #include "SIMPLib/FilterParameters/InputFileFilterParameter.h"
+#include "SIMPLib/FilterParameters/BooleanFilterParameter.h"
 #include "SIMPLib/FilterParameters/LinkedBooleanFilterParameter.h"
 #include "SIMPLib/FilterParameters/StringFilterParameter.h"
 
@@ -109,8 +110,10 @@ void ITKImportFijiMontage::setupFilterParameters()
   parameters.push_back(SIMPL_NEW_INPUT_FILE_FP("Fiji Configuration File", FijiConfigFilePath, FilterParameter::Parameter, ITKImportFijiMontage, "", "*.txt"));
 
   QStringList linkedProps("Origin");
+  linkedProps.push_back("UsePixelCoordinates");
   parameters.push_back(SIMPL_NEW_LINKED_BOOL_FP("Override Origin", ChangeOrigin, FilterParameter::Parameter, ITKImportMontage, linkedProps));
   parameters.push_back(SIMPL_NEW_FLOAT_VEC3_FP("Origin", Origin, FilterParameter::Parameter, ITKImportMontage));
+  parameters.push_back(SIMPL_NEW_BOOL_FP("Pixel Coordinates", UsePixelCoordinates, FilterParameter::Parameter, ITKImportMontage));
 
   linkedProps.clear();
   linkedProps << "Spacing";

--- a/ITKImageProcessingFilters/ITKImportMontage.cpp
+++ b/ITKImageProcessingFilters/ITKImportMontage.cpp
@@ -72,6 +72,7 @@ ITKImportMontage::ITKImportMontage()
 , m_CellAttributeMatrixName(SIMPL::Defaults::CellAttributeMatrixName)
 , m_AttributeArrayName("ImageTile")
 , m_ChangeOrigin(false)
+, m_UsePixelCoordinates(false)
 , m_ChangeSpacing(false)
 , d_ptr(new ITKImportMontagePrivate(this))
 {
@@ -264,15 +265,31 @@ void ITKImportMontage::adjustOriginAndSpacing()
     for(size_t i = 0; i < 3; i++)
     {
       float delta = currentOrigin[i] - d->montageMinCoord[i];
-      // Convert to Pixel Coords
-      delta = delta / currentSpacing[i];
-      // Convert to the override origin
-      delta = delta * overrideSpacing[i];
+      if (m_UsePixelCoordinates)
+      {
+        // Convert to Pixel Coords
+        delta = delta / currentSpacing[i];
+      }
+//      // Convert to the override origin
+//      delta = delta * overrideSpacing[i];
       currentOrigin[i] = overrideOrigin[i] + delta;
+      if (m_UsePixelCoordinates)
+      {
+        // Convert back to physical coords
+        currentOrigin[i] = currentOrigin[i] * currentSpacing[i];
+      }
     }
     imageGeom->setOrigin(currentOrigin.data());
     imageGeom->setSpacing(overrideSpacing.data());
   }
+
+  QString montageInfo;
+  QTextStream ss(&montageInfo);
+  ss << "Columns=" << m_ColumnCount << "  Rows=" << m_RowCount << "  Num. Images=" << montageCacheVector.size();
+
+  ss << "\nOrigin: " << overrideOrigin[0] << ", " << overrideOrigin[1] << ", " << overrideOrigin[2];
+  ss << "  Spacing: " << overrideSpacing[0] << ", " << overrideSpacing[1] << ", " << overrideSpacing[2];
+  m_MontageInformation = montageInfo;
 }
 
 // -----------------------------------------------------------------------------

--- a/ITKImageProcessingFilters/ITKImportMontage.h
+++ b/ITKImageProcessingFilters/ITKImportMontage.h
@@ -68,6 +68,9 @@ class ITKImageProcessing_EXPORT ITKImportMontage : public AbstractFilter
   PYB11_PROPERTY(FloatVec3Type Origin READ getOrigin WRITE setOrigin)
   PYB11_PROPERTY(bool ChangeSpacing READ getChangeSpacing WRITE setChangeSpacing)
   PYB11_PROPERTY(FloatVec3Type Spacing READ getSpacing WRITE setSpacing)
+  PYB11_PROPERTY(QString MontageInformation READ getMontageInformation)
+  PYB11_PROPERTY(int RowCount READ getRowCount)
+  PYB11_PROPERTY(int ColumnCount READ getColumnCount)
   Q_DECLARE_PRIVATE(ITKImportMontage)
 public:
   SIMPL_SHARED_POINTERS(ITKImportMontage)
@@ -90,6 +93,9 @@ public:
   SIMPL_FILTER_PARAMETER(FloatVec3Type, Origin)
   Q_PROPERTY(FloatVec3Type Origin READ getOrigin WRITE setOrigin)
 
+  SIMPL_FILTER_PARAMETER(bool, UsePixelCoordinates)
+  Q_PROPERTY(bool UsePixelCoordinates READ getUsePixelCoordinates WRITE setUsePixelCoordinates)
+
   SIMPL_FILTER_PARAMETER(bool, ChangeSpacing)
   Q_PROPERTY(bool ChangeSpacing READ getChangeSpacing WRITE setChangeSpacing)
 
@@ -102,9 +108,10 @@ public:
   SIMPL_GET_PROPERTY(int, ColumnCount)
   Q_PROPERTY(int ColumnCount READ getColumnCount)
 
-  using MontageCacheVector = std::vector<ITKMontageCache>;
+  SIMPL_GET_PROPERTY(QString, MontageInformation)
+  Q_PROPERTY(QString MontageInformation READ getMontageInformation)
 
-  SIMPL_PIMPL_PROPERTY_DECL(MontageCacheVector, MontageCacheVector)
+  using MontageCacheVector = std::vector<ITKMontageCache>;
 
   /**
    * @brief getCompiledLibraryName Reimplemented from @see AbstractFilter class
@@ -231,6 +238,8 @@ protected:
 
 private:
   QScopedPointer<ITKImportMontagePrivate> const d_ptr;
+
+  QString m_MontageInformation;
 
   int m_RowCount = 0;
   int m_ColumnCount = 0;

--- a/ITKImageProcessingFilters/ITKImportRoboMetMontage.cpp
+++ b/ITKImageProcessingFilters/ITKImportRoboMetMontage.cpp
@@ -10,6 +10,7 @@
 #include "SIMPLib/FilterParameters/FloatVec3FilterParameter.h"
 #include "SIMPLib/FilterParameters/IntFilterParameter.h"
 #include "SIMPLib/FilterParameters/InputFileFilterParameter.h"
+#include "SIMPLib/FilterParameters/BooleanFilterParameter.h"
 #include "SIMPLib/FilterParameters/LinkedBooleanFilterParameter.h"
 #include "SIMPLib/FilterParameters/StringFilterParameter.h"
 #include "SIMPLib/Utilities/StringOperations.h"
@@ -85,8 +86,10 @@ void ITKImportRoboMetMontage::setupFilterParameters()
   parameters.push_back(SIMPL_NEW_STRING_FP("Image File Extension", ImageFileExtension, FilterParameter::Parameter, ITKImportRoboMetMontage));
 
   QStringList linkedProps("Origin");
+  linkedProps.push_back("UsePixelCoordinates");
   parameters.push_back(SIMPL_NEW_LINKED_BOOL_FP("Override Origin", ChangeOrigin, FilterParameter::Parameter, ITKImportMontage, linkedProps));
   parameters.push_back(SIMPL_NEW_FLOAT_VEC3_FP("Origin", Origin, FilterParameter::Parameter, ITKImportMontage));
+  parameters.push_back(SIMPL_NEW_BOOL_FP("Pixel Coordinates", UsePixelCoordinates, FilterParameter::Parameter, ITKImportMontage));
 
   linkedProps.clear();
   linkedProps << "Spacing";

--- a/ITKImageProcessingFilters/ImportAxioVisionV4Montage.cpp
+++ b/ITKImageProcessingFilters/ImportAxioVisionV4Montage.cpp
@@ -154,8 +154,10 @@ void ImportAxioVisionV4Montage::setupFilterParameters()
   parameters.push_back(SIMPL_NEW_BOOL_FP("Import All MetaData", ImportAllMetaData, FilterParameter::Parameter, ImportAxioVisionV4Montage));
 
   QStringList linkedProps("Origin");
+  linkedProps.push_back("UsePixelCoordinates");
   parameters.push_back(SIMPL_NEW_LINKED_BOOL_FP("Change Origin", ChangeOrigin, FilterParameter::Parameter, ImportAxioVisionV4Montage, linkedProps));
   parameters.push_back(SIMPL_NEW_FLOAT_VEC3_FP("Origin", Origin, FilterParameter::Parameter, ImportAxioVisionV4Montage));
+  parameters.push_back(SIMPL_NEW_BOOL_FP("Pixel Coordinates", UsePixelCoordinates, FilterParameter::Parameter, ImportAxioVisionV4Montage));
 
   linkedProps.clear();
   linkedProps << "Spacing";
@@ -549,11 +551,19 @@ void ImportAxioVisionV4Montage::parseImages(QDomElement& root, const ZeissTagsXm
       for(size_t i = 0; i < 3; i++)
       {
         float delta = currentOrigin[i] - minCoord[i];
-        // Convert to Pixel Coords
-        delta = delta / currentSpacing[i];
-        // Convert to the override origin
-        delta = delta * overrideSpacing[i];
+        if (m_UsePixelCoordinates)
+        {
+          // Convert to Pixel Coords
+          delta = delta / currentSpacing[i];
+        }
+        //      // Convert to the override origin
+        //      delta = delta * overrideSpacing[i];
         currentOrigin[i] = overrideOrigin[i] + delta;
+        if (m_UsePixelCoordinates)
+        {
+          // Convert back to physical coords
+          currentOrigin[i] = currentOrigin[i] * currentSpacing[i];
+        }
       }
       image->setOrigin(currentOrigin.data());
       image->setSpacing(overrideSpacing.data());

--- a/ITKImageProcessingFilters/ImportAxioVisionV4Montage.h
+++ b/ITKImageProcessingFilters/ImportAxioVisionV4Montage.h
@@ -125,6 +125,9 @@ public:
   SIMPL_FILTER_PARAMETER(FloatVec3Type, Spacing)
   Q_PROPERTY(FloatVec3Type Spacing READ getSpacing WRITE setSpacing)
 
+  SIMPL_FILTER_PARAMETER(bool, UsePixelCoordinates)
+  Q_PROPERTY(bool UsePixelCoordinates READ getUsePixelCoordinates WRITE setUsePixelCoordinates)
+
   SIMPL_GET_PROPERTY(int32_t, RowCount)
   Q_PROPERTY(int32_t RowCount READ getRowCount)
 


### PR DESCRIPTION
* Adding Pixel Coordinates checkbox to the import montage filters that allows the user to override the origin using coordinates that are in pixel coordinates.
* Updating origin adjustment algorithm so that the overriding the tile spacing does not affect the origins of each tile.