### PR TITLE
Quiet C++17 deprecation warnings on MSVC.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,6 +293,8 @@ target_link_libraries(${plug_target_name}
                     ${ITK_LIBRARIES}
 )
 if(MSVC)
+  # This removes some C++17 Deprecation Warnings inside of ITK 5.1
+  target_compile_definitions(${plug_target_name} PUBLIC "_SILENCE_CXX17_RESULT_OF_DEPRECATION_WARNING")
   set_target_properties(${plug_target_name} PROPERTIES LINK_FLAGS_DEBUG "/INCREMENTAL:NO" )
   # enable per object parallel compilation in this large library
   target_compile_options(${plug_target_name} PRIVATE "/MP" "/bigobj")


### PR DESCRIPTION
Added _SILENCE_CXX17_RESULT_OF_DEPRECATION_WARNING as compile definition

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>